### PR TITLE
2.3 gdb

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -254,6 +254,27 @@ menu "CAmkES Options"
 
     menu "Debugging"
 
+        menuconfig CAMKES_GDB
+        depends on ARCH_ARM
+        bool "Build GDB Server Glue Code"
+        default n
+        help
+            This option calls the debug tool to create GDB interfaces for every selected instance.
+
+        config GDB_ETHERNET
+        bool "Build GDB Server using TCP Connections"
+        depends on CAMKES_GDB && !GDB_SERIAL
+        default y
+        help
+            Builds the GDB Server using TCP as the method of communication between the remote host and the target.
+
+        config GDB_SERIAL
+        bool "Build GDB Server using Serial communications"
+        depends on CAMKES_GDB
+        default n
+        help
+            Builds the GDB Server using UART as the method of communication between the remote host and the target.
+
         config CAMKES_DEBUG_MALLOC
         bool "Enable allocation debugging"
         default n

--- a/LICENSE_DARPA.txt
+++ b/LICENSE_DARPA.txt
@@ -1,0 +1,8 @@
+This repository is additionally covered by the following licensing statements.
+
+-----------------------------------------------------------------------
+
+This data was produced by DornerWorks, Ltd. of Grand Rapids, MI, USA under
+a DARPA SBIR, Contract Number D16PC00107.
+
+Approved for Public Release, Distribution Unlimited.

--- a/camkes/templates/component.simple.c
+++ b/camkes/templates/component.simple.c
@@ -391,7 +391,6 @@ static uintptr_t make_frame_get_paddr(seL4_CPtr untyped) {
             return (uintptr_t)NULL;
         }));
     seL4_CNode_Delete(/*? self_cnode ?*/, /*? holding_slot ?*/, 32);
-    seL4_CNode_Recycle(/*? self_cnode ?*/, untyped, 32);
     return ret;
 }
 

--- a/camkes/templates/component.template.c
+++ b/camkes/templates/component.template.c
@@ -34,6 +34,12 @@
 
 /*? macros.show_includes(me.type.includes) ?*/
 
+/*- if configuration[me.name].get('debug') == '"True"' -*/
+#ifdef CONFIG_CAMKES_GDB
+extern void breakpoint(void);
+#endif
+/*- endif -*/
+
 /*- set putchar = c_symbol() -*/
 static void (* /*? putchar ?*/)(int c);
 
@@ -525,6 +531,13 @@ int USED /*? p['entry_symbol'] ?*/(int thread_id) {
                         }));
                 /*- endif -*/
             /*- endfor -*/
+
+#ifdef CONFIG_CAMKES_GDB
+                   /*- if configuration[me.name].get('debug') == '"True"' -*/
+                        breakpoint();
+                   /*- endif -*/
+#endif
+
             /*- if me.type.control -*/
                 return run();
             /*- else -*/

--- a/toplevel.mk
+++ b/toplevel.mk
@@ -39,8 +39,32 @@ export MAKEFLAGS += $(foreach p, ${CAMKES_IMPORT_PATH}, --include-dir=${p})
 
 include tools/common/project.mk
 
-capdl-loader-experimental: $(filter-out capdl-loader-experimental,$(apps)) parse-capDL ${STAGE_BASE}/cpio-strip/cpio-strip
+capdl-loader-experimental: camkes-debug $(filter-out capdl-loader-experimental,$(apps)) parse-capDL ${STAGE_BASE}/cpio-strip/cpio-strip
 export CAPDL_SPEC:=$(foreach v,$(filter-out capdl-loader-experimental,${apps}),${BUILD_BASE}/${v}/${v}.cdl)
+
+DEBUG_APP:=$(filter-out capdl-loader-experimental,${apps})
+DEBUG_MAKEFILE:=$(APPS_ROOT)/$(DEBUG_APP)/Makefile
+export SOURCE_DIR=$(APPS_ROOT)/$(DEBUG_APP)
+DEBUG_FILE = $(APPS_ROOT)/$(DEBUG_APP)/
+
+camkes-debug:
+ifeq (${CONFIG_CAMKES_GDB},y)
+	@echo "[DEBUG]"
+	@echo " [GEN] $(DEBUG_FILE)"
+	@if [ -e $(DEBUG_MAKEFILE).bk ]; \
+	then ./tools/debug/debug.py -c $(DEBUG_APP).camkes; fi
+	./tools/debug/debug.py $(DEBUG_APP).camkes
+	@echo "[DEBUG] done."
+else
+	@echo "[DEBUG] Option Not Selected"
+	@if [ -e $(DEBUG_MAKEFILE).bk ]; \
+	then ./tools/debug/debug.py -c $(DEBUG_APP).camkes; fi
+endif
+
+camkes-debug-clean:
+	@echo "[CLEAN] CAmkES GDB"
+	@if [ -e $(DEBUG_MAKEFILE).bk ]; then echo " [DEBUG] $(DEBUG_FILE)"; \
+	./tools/debug/debug.py -c $(DEBUG_APP).camkes; fi
 
 # The capdl translator is built in a custom environment to prevent compiler flags
 # intended for the target affecting the compilation of haskell packages intended


### PR DESCRIPTION
Hello, Data61.

I created a CAmkES Debug Tool that is compatible with the ARM architecture and CAmkES 2.3 and uses Ethernet or Serial to communicate with the remote GDB host. 

https://github.com/dornerworks/camkes-debug-tool

This pull request is for the specific CAmkES changes needed to run the tool. DornerWorks would like to hand this tool off to Data61, since more people will benefit from it that way, but it needs some changes for CAmkES 3.1 compatibility. I saw there was some GDB features in the libsel4camkes, so I'm hoping that we can work together to mainline this. 