### PR TITLE
Small DMA boottime improvement and component cleanup suggestions

### DIFF
--- a/camkes/templates/component.template.c
+++ b/camkes/templates/component.template.c
@@ -960,10 +960,12 @@ static int post_main(int thread_id) {
             /*- endif -*/
 
             /*- if me.type.control -*/
-                return run();
-            /*- else -*/
-                return 0;
+                run();
             /*- endif -*/
+                if (on_exit) {
+                    on_exit();
+                }
+                return 0;
 
         /*# Interface threads #*/
         /*- for t in threads[1:] -*/

--- a/camkes/templates/component.template.h
+++ b/camkes/templates/component.template.h
@@ -177,6 +177,8 @@ int run(void);
 /* Optional init functions provided by the user. */
 void pre_init(void) WEAK;
 void post_init(void) WEAK;
+void on_exit(void) WEAK;
+
 /*- for i in all_interfaces -*/
     void /*? i.name ?*/__init(void) WEAK;
 

--- a/libsel4camkes/src/dma.c
+++ b/libsel4camkes/src/dma.c
@@ -140,6 +140,9 @@ static void grow_node(region_t *node, size_t by) {
 /* Check certain assumptions hold on the free list. This function is intended
  * to be a no-op when NDEBUG is defined.
  */
+#ifdef NDEBUG
+static void check_consistency(void) {}
+#else
 static void check_consistency(void) {
     if (head == NULL) {
         /* Empty free list. */
@@ -197,6 +200,7 @@ static void check_consistency(void) {
         }
     }
 }
+#endif
 
 #ifdef NDEBUG
     #define STATS(arg) do { } while (0)


### PR DESCRIPTION
Turning check_consistency into a no-op helps with boot times when using a release build.

The on_exit function has been helpful for putting cleanup or things like profile reporting outside of the main thread of execution.  In our use case we have used it along with the _init functions to initialize and report the profiling statistics of a component without needing to instrument the main function.