### PR TITLE
Set PGD size to 0 when starting at Level 1

### DIFF
--- a/object_sizes/object_sizes.yaml
+++ b/object_sizes/object_sizes.yaml
@@ -42,10 +42,14 @@ seL4_ARM_SuperSectionObject: seL4_SuperSectionBits
 seL4_HugePageObject: seL4_HugePageBits
 #endif
 #ifdef seL4_PGDBits
-seL4_AARCH64_PGDObject: seL4_PGDBits
+#ifdef CONFIG_START_L1
+seL4_AARCH64_PGD: 0
+#else
+seL4_AARCH64_PGD: seL4_PGDBits
+#endif
 #endif
 #ifdef seL4_PUDBits
-seL4_AARCH64_PUDObject: seL4_PUDBits
+seL4_AARCH64_PUD: seL4_PUDBits
 #endif
 #ifdef seL4_IOPageTableBits
 seL4_IOPageTableObject: seL4_IOPageTableBits


### PR DESCRIPTION
This commit also fixes the seL4_AARCH64_PUD and seL4_AARCH64_PGD names
to reflect what is used in capdl.

This allows capdl to structure vspaces differently when running in hyp mode.