### PR TITLE
template: mark symbol as unused to avoid compiler warning

### DIFF
--- a/camkes/templates/seL4HardwareMMIO.template.c
+++ b/camkes/templates/seL4HardwareMMIO.template.c
@@ -96,15 +96,6 @@ void * /*? me.interface.name ?*/_translate_paddr(
     return NULL;
 }
 
-/*- set frame_caps_symbol = c_symbol('frame_caps') -*/
-
-/*# Allocate frame objects to back the hardware dataport #*/
-static const seL4_CPtr /*? frame_caps_symbol ?*/[] = {
-        /*- for cap in frame_caps -*/
-            /*? cap ?*/,
-        /*- endfor -*/
-};
-
 /*- for cap in frame_caps -*/
 __attribute__((used)) __attribute__((section("_dataport_frames")))
 dataport_frame_t /*? me.interface.name ?*//*? loop.index0 ?*/ = {


### PR DESCRIPTION
I'm getting a compiler warning
`error: ‘_camkes_frame_caps_2567’ defined but not used [-Werror=unused-const-variable=]` because nobody seems to use the symbol. This patch declares it as unused to prevent the warning, but still keeps it. I got told that this symbols was used in a `xxx_flush_cache()` function once, but all this has been refactored out into libsel4camkes which obtains the information for the cap from the `dataport_frame_t xxx_0` definition now. So the actual plan seems to be to remove it completely. I would do this, but I'm not a CAmkES template expert and thus not sure what else should be remove there. Instead, I go with the minimal invasive change now and just declare it as unused. 