### PR TITLE
config: include configuration header file

### DIFF
--- a/camkes/templates/seL4HardwareInterrupt.template.c
+++ b/camkes/templates/seL4HardwareInterrupt.template.c
@@ -196,7 +196,7 @@ int /*? me.interface.name ?*/__run(void) {
                                                 /*? me.interface.name ?*/_acknowledge_cb,
                                                 NULL);
         } else {
-            ZF_LOGE("No mechanism exists to handle this interrupt, this interrupt will be ignored");
+            ZF_LOGE("No mechanism exists to handle this interrupt, it will be ignored");
         }
     }
 

--- a/libsel4camkes/include/camkes/tls.h
+++ b/libsel4camkes/include/camkes/tls.h
@@ -14,6 +14,8 @@
 
 /* Thread-local storage functionality for CAmkES. */
 
+#include <sel4camkes/gen_config.h>
+
 #include <assert.h>
 #include <sel4/sel4.h>
 #include <stdalign.h>


### PR DESCRIPTION
Include the generated configuration header file to avoid a warning about the undefined TLS model.