### PR TITLE
RISCV: Added support for riscv interrupts in dtb-query-common

### DIFF
--- a/camkes/templates/seL4DTBHardware-to.template.c
+++ b/camkes/templates/seL4DTBHardware-to.template.c
@@ -133,7 +133,7 @@
 
     /*# CAmkES has a maximum limit of 28 bits for badges, #*/
     /*# highly unlikely a device has greater than 28 #*/
-    /*? dtb_macros.parse_dtb_node_interrupts(dtb, 28) ?*/
+    /*? dtb_macros.parse_dtb_node_interrupts(dtb, 28, options.architecture) ?*/
     /*- set irq_set = pop('irq_set') -*/
 
     /*- for (_irq, i) in zip(irq_set, range(0, len(irq_set)))  -*/


### PR DESCRIPTION
The ARM version expected a certain encoding in the interrupts cells of
the dtb. This encoding is not present in the hifive dts and therefore
was generating the wrong interrupt templates.

Change-Id: I024aa847d0429bb348a88e7b6a851e32250d14e2