### PR TITLE
output: update and check FIFO for every char

### DIFF
--- a/libsel4camkes/src/sel4_arch/ia32/gdb_server/serial.c
+++ b/libsel4camkes/src/sel4_arch/ia32/gdb_server/serial.c
@@ -343,19 +343,25 @@ static bool clear_iir(void)
     return false;
 }
 
-// Serial usage
-static void serial_putchar(int c)
+static void serial_output_via_fifo(uint8_t c)
 {
     // check how much fifo we've used and if we need to drain it
     if (fifo_used == fifo_depth) {
         wait_for_fifo();
     }
-    write_thr((uint8_t)c);
-    if (c == '\n') {
-        wait_for_fifo();
-        write_thr('\r');
-    }
+
+    write_thr(c);
     fifo_used++;
+}
+
+// Serial usage
+static void serial_putchar(int c)
+{
+    if (c == '\n') {
+        serial_output_via_fifo('\r');
+    }
+
+    serial_output_via_fifo((uint8_t)c);
 }
 
 


### PR DESCRIPTION
I think the FIFO must be checked for every char that is sent, otherwise the char could be lost. Issue might not happen in real life by luck, because things are never pushed to the limits.