### PR TITLE
camkes: Fix build breaker

### DIFF
--- a/camkes/templates/camkes-gen.cmake
+++ b/camkes/templates/camkes-gen.cmake
@@ -306,11 +306,11 @@ RequireFile(CONFIGURE_FILE_SCRIPT configure_file.cmake PATHS ${CMAKE_MODULE_PATH
     # Add interface header files to camkes.h
     file(WRITE "${generated_dir}/include/camkes.h.cmd" "${CMAKE_COMMAND} -DCONFIGURE_INPUT_FILE=\"${generated_dir}/include/camkes.h.in\" \
         -DCONFIGURE_OUTPUT_FILE=\"${generated_dir}/include/camkes.h\" -DCMAKE_INTERFACE_INCLUDES=\"${CMAKE_INTERFACE_INCLUDES}\" -P ${CONFIGURE_FILE_SCRIPT}")
-    add_custom_command(OUTPUT /*? i.name ?*//include/camkes.h
+    add_custom_command(OUTPUT ${generated_dir}/include/camkes.h
         COMMAND sh "${generated_dir}/include/camkes.h.cmd"
         DEPENDS "${generated_dir}/include/camkes.h.in" "${generated_dir}/include/camkes.h.cmd"
         )
-    set_property(SOURCE /*? i.name ?*//camkes.c PROPERTY OBJECT_DEPENDS /*? i.name ?*//include/camkes.h)
+    set_property(SOURCE /*? i.name ?*//camkes.c PROPERTY OBJECT_DEPENDS ${generated_dir}/include/camkes.h)
 
     # Create a target for all our generated files
     set(gen_target /*? i.name ?*/_generated)


### PR DESCRIPTION
The change of https://github.com/seL4/camkes-tool/commit/80ce2676941d0ebece38d66f803f7fa0051fa1a7 does not work for me, the build always fails with 

    ninja: error: 'main/include/camkes.h', 
    needed by '<my_system>/CMakeFiles/main.instance.bin.dir/main/camkes.c.obj', 
    missing and no known rule to make it

where `<my_system>` is a custom sub folder I'm using to place my CAMkES system in to avoid naming conflicts.
This patch fixed the build for me. But I don't fully understand the what the original commit tried to do and by fix here might contradict this.