### PR TITLE
github: add basic style CI checks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,28 @@
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Actions to run on pull requests
+
+name: PR
+
+on: [pull_request]
+
+jobs:
+  gitlint:
+    name: Gitlint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: seL4/ci-actions/gitlint@master
+
+  whitespace:
+    name: 'Trailing Whitespace'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: seL4/ci-actions/git-diff-check@master
+
+  shell:
+    name: 'Portable Shell'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: seL4/ci-actions/bashisms@master

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,34 @@
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Actions to run on Push and Pull Request
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+#  Removed until license tags are converted to SPDX:
+#  check:
+#    name: License Check
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: seL4/ci-actions/license-check@master
+
+  links:
+    name: Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: seL4/ci-actions/link-check@master
+        with:
+          exclude: js/node_modules
+
+  style:
+    name: Style
+    runs-on: ubuntu-latest
+    steps:
+    - uses: seL4/ci-actions/style@master

--- a/.licenseignore
+++ b/.licenseignore
@@ -1,5 +1,6 @@
 .gitignore
 .git/**
+.github/**
 VERSION
 CHANGES
 .licenseignore


### PR DESCRIPTION
The `reuse` license check is commented out until the repo is converted to SPDX tags.
