### PR TITLE
runner: Fix generate_seL4SignalRecv

### DIFF
--- a/camkes/runner/Context.py
+++ b/camkes/runner/Context.py
@@ -292,7 +292,7 @@ def generate_seL4_SignalRecv(options, dest_ntfn_cap, dest_msginfo_var_name, src_
     if options.realtime:
         return 'seL4_NBSendRecv(%s, %s, %s, %s, %s)' % (dest_ntfn_cap, dest_msginfo_var_name, src_ep_cap, badge_var_name, reply_cap)
     else:
-        return 'seL4_SignalRecv(%s, %s, %s)' % (dest_ntfn_cap, src_ep_cap, badge_var_name)
+        return 'seL4_Signal(%s); %s = seL4_Recv(%s, %s)' % (dest_ntfn_cap, dest_msginfo_var_name, src_ep_cap, badge_var_name)
 
 
 def generate_seL4_ReplyRecv(options, src_ep_cap, dest_msginfo_var_name, badge_var_name, reply_cap):


### PR DESCRIPTION
seL4SignalRecv does not exist in the normal kernel, this commit splits
the two calls so that the compilable code can be generated.