### PR TITLE
camkes,rumprun: Fix TLS management implementation

### DIFF
--- a/camkes/templates/linker.lds
+++ b/camkes/templates/linker.lds
@@ -14,6 +14,7 @@
 
 /*- set instances = composition.instances -*/
 /*- set grouped = [False] -*/
+/*- set rump = configuration[me.name].get('rump_config', False) -*/
 
 /*# For single address space components we need to collect constructors
  *# and destructors early in order to prevent them from being called
@@ -59,7 +60,7 @@ SECTIONS {
   /*- endfor -*/
 }
 INSERT AFTER .bss;
-/*- if not grouped[0] -*/
+/*- if not grouped[0] and not rump -*/
 SECTIONS {
     .tdata :
     {


### PR DESCRIPTION
The correct functioning of the thread-local-storage implementation
requires the linker to correctly initialize _tbss_end and _tdata_start
variables to sizes that reflect the true size of the static TLS region.
In order for this to work, these variables can only be declared in the
final linking stage of the executable. In the case of Rumprun camkes
components, there is an additional linker step where the rumprun
userlevel binaries are linked with the rumprun base (which is what the
camkes templated linker script refers to.). So this case must be handled
similarly to grouped components, where the .tdata_* and .tbss_* linker
symbol declarations are suppressed until the final link step.

Signed-off-by: Kent McLeod <kent.mcleod@protonmail.com>

Fixes seL4/camkes-manifest#5