### PR TITLE
Add static attribute

### DIFF
--- a/camkes/parser/camkes.g
+++ b/camkes/parser/camkes.g
@@ -74,7 +74,7 @@ ID: '[a-zA-Z_]\w*'
             TRUE1: 'True';
             TRUE2: 'true';
             TO: 'to';
-            UINT64_T: 'uint64_t'; 
+            UINT64_T: 'uint64_t';
             UNSIGNED: 'unsigned';
             USES: 'uses';
             VOID: 'void';

--- a/camkes/templates/component.template.h
+++ b/camkes/templates/component.template.h
@@ -31,10 +31,20 @@
 const char *get_instance_name(void);
 
 /* Attributes */
+
+// This macro allows using attributes as "rvalues" e.g. in the array size
+// declarations. Unfortunately, the C language (in contrast to C++) does not
+// support using "lvalues" in this case, even if declared as const.
+#define CAMKES_CONST_ATTR(attr) attr##_DEF
+
 /*- set myconf = configuration[me.name] -*/
 /*? macros.print_type_definitions(me.type.attributes, myconf) ?*/
 /*- for a in me.type.attributes -*/
     /*- set value = myconf.get(a.name) -*/
+    /*- if value is not none -*/
+        #define /*? a.name ?*/_DEF /*? macros.show_attribute_value(a, value) ?*/
+    /*- endif -*/
+
     extern const /*? macros.show_type(a.type) ?*/ /*? a.name ?*/ /*- if a.array -*/ [/*?len(value)?*/] /*- endif -*/;
 /*- endfor -*/
 

--- a/camkes/templates/macros.py
+++ b/camkes/templates/macros.py
@@ -226,7 +226,7 @@ def show_attribute_value(t, value):
     if isinstance(value, (tuple, list)):
         is_array = True
         values = value
-        return_string += "{\n"
+        return_string += "{\\\n"
     else:
         values = (value,)
 
@@ -235,18 +235,18 @@ def show_attribute_value(t, value):
         if isinstance(value, six.string_types):  # For string literals
             return_string += "\"%s\"" % value
         elif isinstance(t.type, Struct):  # For struct attributes (This recursively calls this function)
-            return_string += "{\n"
+            return_string += "{\\\n"
             for attribute in t.type.attributes:
                 return_string += "." + str(attribute.name)  # + ("[]" if attribute.array else "")
                 return_string += " = " + \
-                    str(show_attribute_value(attribute, value[attribute.name])) + ",\n"
+                    str(show_attribute_value(attribute, value[attribute.name])) + ",\\\n"
             return_string += "}"
         else:  # For all other literal types
             return_string += "%s" % str(value)
 
         # Add comma if element is part of an array
         if i < (len(values)-1):
-            return_string += ",\n"
+            return_string += ",\\\n"
     if is_array:
         return_string += "}"
     return return_string

--- a/docs/index.md
+++ b/docs/index.md
@@ -1696,6 +1696,45 @@ const char * a = "Hello, World!";
 const int b = 42;
 ```
 
+#### Attribute's conversion to literal
+
+Unfortunately, the `C` language (in contrast to C++) does not support using
+`lvalues` as literals (e.g. when declaring an array), even if declared as const,
+so we need to introduce a "mechanism" for converting CAmkES attributes to
+literals.
+
+The `CAMKES_CONST_ATTR` macro has been introduced for that purpose.
+
+Actually, the macro does not really convert arbitrary variables, but rather
+CAmkES declares a const variable and also adds a respective macro to the code,
+which is then used for that purpose.
+
+Usage example is presented below:
+
+```C
+/* main.camkes */
+assembly {
+    composition {
+        component FOO foo;
+    }
+    configuration {
+        foo.lenData  = 16;
+    }
+}
+
+/* Foo.c */
+const int foo[CAMKES_CONST_ATTR(lenData)] = { 0 };
+
+int run()
+{
+#if CAMKES_CONST_ATTR(lenData) < 0xF0
+    return 0;
+#else
+    return 1;
+#endif
+}
+```
+
 ### Hardware Components
 
 A hardware component represents an interface to hardware in the form of a component.


### PR DESCRIPTION
CAmkES was missing a way of creating a static attributes (evaluated at
the compile time).

Thanks to this, we can e.g. have arrays of a size that are component's
instance specific:

```
// foo.camkes
component Foo {
    static_attribute N = 1;

// foo.c
static int data[N];
}

// main.camkes
assembly {
    composition {
        component   Foo      foo;
        component   Foo      bar;
    }

    configuration {
        foo.N = 10;
        bar.N = 20;
    }
}
```