### PR TITLE
libsel4camkes: make uname generic, add RISC-V

### DIFF
--- a/libsel4camkes/src/sys_uname.c
+++ b/libsel4camkes/src/sys_uname.c
@@ -52,60 +52,39 @@ long camkes_sys_uname(va_list ap)
 
     /* Set hardware information. */
     char *arch;
-    if (config_set(CONFIG_ARCH_ARM)) {
-        arch = "ARM";
-    } else if (config_set(CONFIG_ARCH_X86)) {
-        arch = "x86";
-    } else {
-        arch = "unknown";
-    }
-    char *armv;
-    if (config_set(CONFIG_ARM_V6)) {
-        armv = "v6";
-    } else if (config_set(CONFIG_ARM_V7A)) {
-        armv = "v7a";
-    } else if (config_set(CONFIG_ARM_V8A)) {
-        armv = "v8a";
-    } else {
-        armv = "";
-    }
+    char *arch_ver;
     char *plat;
-    if (config_set(CONFIG_PLAT_KZM)) {
-        plat = "KZM";
-    } else if (config_set(CONFIG_PLAT_OMAP3)) {
-        plat = "OMAP3";
-    } else if (config_set(CONFIG_PLAT_ARM335X)) {
-        plat = "ARM335X";
-    } else if (config_set(CONFIG_PLAT_EXYNOS4)) {
-        plat = "EXYNOS4";
-    } else if (config_set(CONFIG_PLAT_EXYNOS5410)) {
-        plat = "EXYNOS5410";
-    } else if (config_set(CONFIG_PLAT_EXYNOS5422)) {
-        plat = "EXYNOS5422";
-    } else if (config_set(CONFIG_PLAT_EXYNOS5250)) {
-        plat = "EXYNOS5250";
-    } else if (config_set(CONFIG_PLAT_APQ8064)) {
-        plat = "APQ8064";
-    } else if (config_set(CONFIG_PLAT_SABRE)) {
-        plat = "IMX6";
-    } else if (config_set(CONFIG_PLAT_WANDQ)) {
-        plat = "WANDQ";
-    } else if (config_set(CONFIG_PLAT_IMX7_SABRE)) {
-        plat = "IMX7";
-    } else if (config_set(CONFIG_PLAT_ZYNQ7000)) {
-        plat = "ZYNQ7000";
-    } else if (config_set(CONFIG_PLAT_PC99)) {
-        plat = "PC99";
-    } else if (config_set(CONFIG_PLAT_ALLWINNERA20)) {
-        plat = "ALLWINNERA20";
-    } else if (config_set(CONFIG_PLAT_TK1)) {
-        plat = "TK1";
-    } else if (config_set(CONFIG_PLAT_HIKEY)) {
-        plat = "HIKEY";
-    } else {
-        plat = "unknown";
-    }
-    snprintf(buf->machine, sizeof buf->machine, "%s%s %s", arch, armv, plat);
+
+#if defined(CONFIG_ARCH_ARM)
+    arch = "ARM";
+    plat = STRINGIFY(CONFIG_ARM_PLAT);
+#if defined(CONFIG_ARCH_ARM_V6)
+    arch_ver = "v6";
+#elif defined(CONFIG_ARCH_ARM_V7A)
+    arch_ver = "v7a";
+#elif defined(CONFIG_ARCH_ARM_V7VE)
+    arch_ver = "v7a-ve";
+#elif defined(CONFIG_ARCH_ARM_V8A)
+    arch_ver = "v8a, " STRINGIFY(CONFIG_SEL4_ARCH);
+#else
+#error "please define ARM architecture"
+#endif
+
+#elif defined(CONFIG_ARCH_RISCV)
+    arch = "RISC-V";
+    arch_ver = ", " STRINGIFY(CONFIG_SEL4_ARCH);
+    plat = STRINGIFY(CONFIG_RISCV_PLAT)
+
+#elif defined(CONFIG_ARCH_IA32) || defined(CONFIG_ARCH_X86_64)
+    arch = STRINGIFY(CONFIG_SEL4_ARCH);
+    arch_ver = "";
+    plat = "pc99";
+
+#else
+#error "please define configuration"
+#endif
+
+    snprintf(buf->machine, sizeof buf->machine, "%s (%s%s)", plat, arch, arch_ver);
 
     /* Set the domain name. */
 #if _GNU_SOURCE


### PR DESCRIPTION
make it generic, so there is no immediate need to modify this file when adding a new platform.