### PR TITLE
camkes: Add feature to get the dataport size

### DIFF
--- a/camkes/templates/component.template.h
+++ b/camkes/templates/component.template.h
@@ -213,6 +213,11 @@ const char *get_instance_name(void);
     #define /*? d.name ?*/_release() COMPILER_MEMORY_RELEASE()
     #define /*? d.name ?*/_acquire() COMPILER_MEMORY_ACQUIRE()
 
+    #define /*? d.name ?*/_size /*? macros.dataport_size(d.type) ?*/
+
+    static inline size_t /*? d.name ?*/_get_size(void) {
+      return /*? macros.dataport_size(d.type) ?*/;
+    }
 /*- endfor -*/
 
 /*- for m in me.type.mutexes -*/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1343,6 +1343,14 @@ The following functions are available at runtime:
   emitted if necessary, depending on the affinities of component instances
   connected by the dataport.
 
+**`size_t`&nbsp;_`dataport`_`_get_size(void)`**
+
+> Returns the size for the specific dataport this function gets called for. In
+  addition to this function, every component that has a dataport will be
+  provided with a macro _`dataport`_`_size` that is defined to the size of the
+  invdividual dataport. This macro allows declaring fixed size arrays, as the
+  `C` language requires a constant-expression for this.
+
 **`void *camkes_dma_alloc(size_t size, int align)`** (`#include <camkes/dma.h>`)
 **`void camkes_dma_free(void *ptr, size_t size)`** (`#include <camkes/dma.h>`)
 


### PR DESCRIPTION
Adds a variable for every dataport a component has that
holds the size of the specific dataport.

Signed-off-by: Matthias Buhl <matthias.buhl@hensoldt-cyber.de>