### PR TITLE
camkes-tool: create file in current working directory

### DIFF
--- a/camkes.cmake
+++ b/camkes.cmake
@@ -538,6 +538,8 @@ function(GenerateCAmkESRootserver)
             ${${command}}
             --makefile-dependencies
             "${deps_file}"
+            WORKING_DIRECTORY
+            "${CMAKE_CURRENT_BINARY_DIR}"
             INPUT_FILE
             /dev/stdin
             OUTPUT_FILE

--- a/camkes/parser/stage0.py
+++ b/camkes/parser/stage0.py
@@ -37,9 +37,7 @@ class CPP(Parser):
     def __init__(self, cpp_bin='cpp', flags=None):
         self.cpp_bin = cpp_bin
         self.flags = flags or []
-        self.out_dir = os.path.join(os.getcwd(), 'camkes-tool')
-        if not os.path.isdir(self.out_dir):
-            os.mkdir(self.out_dir)
+        self.out_dir = os.getcwd()
 
     def parse_file(self, filename):
         # Run cpp with -MD to generate dependencies because we want to


### PR DESCRIPTION
1.  Simplify CMake files
2. Set the current working directory explicitly to be the build output folder. This was missing in the past and thus the fiels were not necessarily created in the folder where the build output is, but form where the build was started. Since most build script seem to do `cd <build-out-dir>; cmake ....` this was not noticed. But if `cmake -S <src> -B <build-output> ...` is used, the files suddenly pop up in a subfolder of the folder where the build is invoked and not in `<build-output>`.
3. Let the CAmkES parser create the output files in the current working directory and don't create a subfolder - this was needed due to the "bug" that (2) "fixes" now. One day the parser could get a parameter that allows defining where the output goes. Until then, simply use the current working directly and avoid any fancy things. 