### PR TITLE
camkes: add i.MX6 Nitrogen6_SoloX board

### DIFF
--- a/libsel4camkes/src/sys_uname.c
+++ b/libsel4camkes/src/sys_uname.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2020, HENSOLDT Cyber GmbH
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -90,6 +91,8 @@ long camkes_sys_uname(va_list ap)
         plat = "IMX6";
     } else if (config_set(CONFIG_PLAT_WANDQ)) {
         plat = "WANDQ";
+    } else if (config_set(CONFIG_PLAT_NITROGEN6SX)) {
+        plat = "NITROGEN6SX";
     } else if (config_set(CONFIG_PLAT_IMX7_SABRE)) {
         plat = "IMX7";
     } else if (config_set(CONFIG_PLAT_ZYNQ7000)) {


### PR DESCRIPTION
Patch is part of a series of patches to add support for the i.MX6 Nitrogen6_SoloX board

* https://github.com/seL4/seL4_tools/pull/53
* https://github.com/seL4/seL4/pull/309