### PR TITLE
camkes: Allow component to know affinity

### DIFF
--- a/camkes/templates/component.common.c
+++ b/camkes/templates/component.common.c
@@ -74,6 +74,14 @@ const char *get_instance_name(void) {
     return name;
 }
 
+int get_instance_core(void) {
+/*- if 'affinity' in configuration[me.name].keys() -*/
+    return /*? configuration[me.name].get('affinity') ?*/;
+/*- else -*/
+    return 0;
+/*- endif -*/
+}
+
 /*- set cnode_size = configuration[me.address_space].get('cnode_size_bits') -*/
 /*- if cnode_size -*/
         /*- if isinstance(cnode_size, six.string_types) -*/

--- a/camkes/templates/component.template.h
+++ b/camkes/templates/component.template.h
@@ -23,6 +23,7 @@
 /*- endfor -*/
 
 const char *get_instance_name(void);
+int get_instance_core(void);
 
 /* Attributes */
 


### PR DESCRIPTION
This commit adds in a function to allow a CAmkES component to query its affinity.

Signed-off-by: Damon Lee <Damon.Lee@data61.csiro.au>