### PR TITLE
camkes: add default value for return value in rpc connector from

### DIFF
--- a/camkes/templates/rpc-connector-common-from.c
+++ b/camkes/templates/rpc-connector-common-from.c
@@ -54,7 +54,7 @@
 
     unsigned size;
     /*-- if m.return_type is not none -*/
-      /*? macros.show_type(m.return_type) ?*/ return_val;
+      /*? macros.show_type(m.return_type) ?*/ return_val = { 0 };
       /*? macros.show_type(m.return_type) ?*/ *return_ptr = &return_val;
     /*- endif -*/
 


### PR DESCRIPTION
The  latest version of cppcheck complain about some uninitialized variables being used in generated code.

16:08:20  timeServer_rpc_seL4RPCCall_1.c:238:24: error: Uninitialized variable: *return_ptr [uninitvar]
16:08:20                  return * return_ptr;
16:08:20                         ^
16:08:20  timeServer_rpc_seL4RPCCall_1.c:229:32: note: Address of variable taken here.
16:08:20        OS_Error_t *return_ptr = &return_val;
16:08:20                                 ^
16:08:20  timeServer_rpc_seL4RPCCall_1.c:238:24: note: Uninitialized variable: *return_ptr
16:08:20                  return * return_ptr;
16:08:20                         ^
16:08:20  timeServer_rpc_seL4RPCCall_1.c:370:24: error: Uninitialized variable: *return_ptr [uninitvar]
16:08:20                  return * return_ptr;
16:08:20                         ^
16:08:20  timeServer_rpc_seL4RPCCall_1.c:359:32: note: Address of variable taken here.
16:08:20        OS_Error_t *return_ptr = &return_val;