### PR TITLE
camkes: Allow c++ source files to be used for the creation camkes components

### DIFF
--- a/camkes.cmake
+++ b/camkes.cmake
@@ -577,6 +577,7 @@ endfunction(GenerateCAmkESRootserver)
 #   SOURCES <src1> <src2> ...
 #   INCLUDES <inc1> <inc2> ...
 #   C_FLAGS <flag1> <flag2> ...
+#   CXX_FLAGS <flag1> <flag2> ...
 #   LD_FLAGS <flag1> <flag2> ...
 #   LIBS <lib1> <lib1> ...
 #
@@ -605,7 +606,7 @@ function(AppendCAmkESComponentTarget target_name)
         CAMKES_COMPONENT
         "" # Option arguments
         "CAKEML_HEAP_SIZE;CAKEML_STACK_SIZE;LINKER_LANGUAGE" # Single arguments
-        "SOURCES;CAKEML_SOURCES;CAKEML_DEPENDS;CAKEML_INCLUDES;INCLUDES;C_FLAGS;LD_FLAGS;LIBS;TEMPLATE_SOURCES;TEMPLATE_HEADERS" # Multiple aguments
+        "SOURCES;CAKEML_SOURCES;CAKEML_DEPENDS;CAKEML_INCLUDES;INCLUDES;C_FLAGS;CXX_FLAGS;LD_FLAGS;LIBS;TEMPLATE_SOURCES;TEMPLATE_HEADERS" # Multiple aguments
     )
     # Declare a target that we will set properties on
     if(NOT (TARGET "${target_name}"))
@@ -663,6 +664,11 @@ function(AppendCAmkESComponentTarget target_name)
         TARGET "${target_name}"
         APPEND
         PROPERTY COMPONENT_C_FLAGS "${CAMKES_COMPONENT_C_FLAGS}"
+    )
+    set_property(
+        TARGET "${target_name}"
+        APPEND
+        PROPERTY COMPONENT_CXX_FLAGS "${CAMKES_COMPONENT_CXX_FLAGS}"
     )
     set_property(
         TARGET "${target_name}"

--- a/camkes/templates/camkes-gen.cmake
+++ b/camkes/templates/camkes-gen.cmake
@@ -181,6 +181,8 @@ RequireFile(CONFIGURE_FILE_SCRIPT configure_file.cmake PATHS ${CMAKE_MODULE_PATH
     list(APPEND static_sources "$<TARGET_PROPERTY:${instance_target},COMPONENT_SOURCES>")
     set(extra_c_flags "$<TARGET_PROPERTY:CAmkESComponent_/*? i.type.name ?*/,COMPONENT_C_FLAGS>")
     list(APPEND extra_c_flags "$<TARGET_PROPERTY:${instance_target},COMPONENT_C_FLAGS>")
+    set(extra_cxx_flags "$<TARGET_PROPERTY:CAmkESComponent_/*? i.type.name ?*/,COMPONENT_CXX_FLAGS>")
+    list(APPEND extra_cxx_flags "$<TARGET_PROPERTY:${instance_target},COMPONENT_CXX_FLAGS>")
     get_property(extra_ld_flags TARGET "CAmkESComponent_/*? i.type.name ?*/" PROPERTY COMPONENT_LD_FLAGS)
     get_property(component_extra_ld_flags TARGET "${instance_target}" PROPERTY COMPONENT_LD_FLAGS)
     list(APPEND extra_ld_flags "${component_extra_ld_flags}")
@@ -350,7 +352,8 @@ RequireFile(CONFIGURE_FILE_SCRIPT configure_file.cmake PATHS ${CMAKE_MODULE_PATH
     set_property(TARGET ${target} APPEND_STRING PROPERTY LINK_FLAGS
         " -static -nostdlib -u _camkes_start -e _camkes_start ")
     # Add extra flags specified by the user
-    target_compile_options(${target} PRIVATE ${extra_c_flags} ${CAMKES_C_FLAGS})
+    target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:C>:${extra_c_flags} ${CAMKES_C_FLAGS}>)
+    target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${extra_cxx_flags} ${CAMKES_CXX_FLAGS}>)
     foreach(extra_ld_flag IN LISTS extra_ld_flags)
         set_property(TARGET ${target} APPEND_STRING PROPERTY LINK_FLAGS ${extra_ld_flag})
     endforeach()


### PR DESCRIPTION
Allows C++ source files to be used in the creation of camkes components. Extends the DeclareCAmkESComponent function with the CXX_FLAGS argument.