### PR TITLE
GitHub action for CAmkES CLI tests

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -16,7 +16,7 @@ jobs:
   new:
     name: New Project
     runs-on: ubuntu-latest
-    container: trustworthy-systems/camkes
+    container: trustworthysystems/camkes:latest
     steps:
     - uses: actions/checkout@v2
     - run: pip3 install --user --upgrade camkes-cli

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -16,11 +16,9 @@ jobs:
   new:
     name: New Project
     runs-on: ubuntu-latest
+    container: trustworthy-systems/camkes
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
     - run: pip3 install --user --upgrade camkes-cli
     - run: |
         PATH=$PATH:$HOME/.local/bin camkes-cli new hello --template hello_world

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,6 +17,7 @@ jobs:
     name: New Project
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
         python-version: '3.8'

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -10,6 +10,7 @@ on:
   schedule:
     - cron: '3 17 * * *'   # 17:03 UTC
   workflow_dispatch:
+  pull_request:
 
 jobs:
   new:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,39 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Test the (released) camkes-cli python package
+
+name: CLI
+
+on:
+  schedule:
+    - cron: '3 17 * * *'   # 17:03 UTC
+  workflow_dispatch:
+
+jobs:
+  new:
+    name: New Project
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - run: pip3 install --user --upgrade camkes-cli
+    - run: |
+        PATH=$PATH:$HOME/.local/bin camkes-cli new hello --template hello-world
+    - run: |
+        expect -c "
+          set timeout 180
+          cd hello
+          spawn $HOME/.local/bin/camkes-cli run x86
+          expect {
+            \\\"Hello, World!\\\" { close }
+            default { exit 1 }
+          }"
+
+  existing:
+    name: Existing Project
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo later

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: '3.8'
     - run: pip3 install --user --upgrade camkes-cli
     - run: |
-        PATH=$PATH:$HOME/.local/bin camkes-cli new hello --template hello-world
+        PATH=$PATH:$HOME/.local/bin camkes-cli new hello --template hello_world
     - run: |
         expect -c " \
           set timeout 180 \

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -24,13 +24,13 @@ jobs:
     - run: |
         PATH=$PATH:$HOME/.local/bin camkes-cli new hello --template hello-world
     - run: |
-        expect -c "
-          set timeout 180
-          cd hello
-          spawn $HOME/.local/bin/camkes-cli run x86
-          expect {
-            \\\"Hello, World!\\\" { close }
-            default { exit 1 }
+        expect -c " \
+          set timeout 180 \
+          cd hello \
+          spawn $HOME/.local/bin/camkes-cli run x86 \
+          expect { \
+            \\\"Hello, World!\\\" { close } \
+            default { exit 1 } \
           }"
 
   existing:


### PR DESCRIPTION
These test the released `camkes-cli` package, so they don't trigger on repo changes, but are scheduled to run once a day.
