### PR TITLE
Add GitHub action for CAmkES Unit tests

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,20 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# CAmkES unit tests
+
+name: Unit
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  unit:
+    name: 'Unit Tests'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: seL4/ci-actions/camkes-unit@master


### PR DESCRIPTION
Still has to pointed at `camkes-unit@master` when  seL4/ci-actions#105 is merged.