### PR TITLE
RISC-V: Support DTBs with one interrupt value per cell

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Upcoming release
 
 ## Changes
 
+* Added RISC-V in `is_64_bit_arch()`
 
 ## Upgrade Notes
 ---

--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,11 @@ Upcoming release
 ## Changes
 
 * Added RISC-V in `is_64_bit_arch()`
+* Added helpers `is_arch_arm()` and `is_arch_riscv()`
+* Added an additional parameter with the current architectures for the macros
+  `parse_dtb_node_interrupts()` and `global_endpoint_badges()`.
+* Extended DTB interrupt property parsing to support either one value or three
+  values per interrupt. For three values, ignore the first value on RISC-V.
 
 ## Upgrade Notes
 ---

--- a/camkes/templates/arch_helpers.py
+++ b/camkes/templates/arch_helpers.py
@@ -13,6 +13,14 @@ def is_64_bit_arch(arch):
     return arch in ('x86_64', 'aarch64', 'riscv64')
 
 
+def is_arch_arm(arch):
+    return arch in ('aarch32', 'arm_hyp', 'aarch64')
+
+
+def is_arch_riscv(arch):
+    return arch in ('riscv32', 'riscv64')
+
+
 def min_untyped_size(arch):
     return 4
 

--- a/camkes/templates/arch_helpers.py
+++ b/camkes/templates/arch_helpers.py
@@ -8,11 +8,14 @@
 Helpers for accessing architecture-specific information
 '''
 
+
 def is_64_bit_arch(arch):
     return arch in ('x86_64', 'aarch64')
 
+
 def min_untyped_size(arch):
     return 4
+
 
 def max_untyped_size(arch):
     if is_64_bit_arch(arch):

--- a/camkes/templates/arch_helpers.py
+++ b/camkes/templates/arch_helpers.py
@@ -10,7 +10,7 @@ Helpers for accessing architecture-specific information
 
 
 def is_64_bit_arch(arch):
-    return arch in ('x86_64', 'aarch64')
+    return arch in ('x86_64', 'aarch64', 'riscv64')
 
 
 def min_untyped_size(arch):

--- a/camkes/templates/dtb-query-common.template.c
+++ b/camkes/templates/dtb-query-common.template.c
@@ -45,7 +45,7 @@
     /*- do stash('reg_set', reg_set) -*/
 /*- endmacro -*/
 
-/*- macro parse_dtb_node_interrupts(node, max_num_interrupts) -*/
-    /*- set irq_set = macros.parse_dtb_node_interrupts(node, max_num_interrupts) -*/
+/*- macro parse_dtb_node_interrupts(node, max_num_interrupts, arch) -*/
+    /*- set irq_set = macros.parse_dtb_node_interrupts(node, max_num_interrupts, arch) -*/
     /*- do stash('irq_set', irq_set) -*/
 /*- endmacro -*/

--- a/camkes/templates/seL4DTBHardware-to.template.c
+++ b/camkes/templates/seL4DTBHardware-to.template.c
@@ -95,7 +95,7 @@
 
         /* Flush data corresponding to the dataport-relative address range from the CPU cache */
         int /*? reg_interface_name ?*/_flush_cache(size_t start_offset UNUSED, size_t size UNUSED, dma_cache_op_t cache_op UNUSED) {
-            return camkes_dataport_flush_cache(start_offset, size, 
+            return camkes_dataport_flush_cache(start_offset, size,
                                                (uintptr_t) &/*? dataport_symbol_name ?*/.content,
                                                /*? size ?*/, cache_op);
         }
@@ -186,7 +186,7 @@
                     } else if (/*? me.interface.name ?*/_irq_handle) {
                         /*? me.interface.name ?*/_irq_handle(&irq);
                     } else if (/*? interrupt_struct_prefix ?*/_/*? i ?*/.is_allocated) {
-                        /*? interrupt_struct_prefix ?*/_/*? i ?*/.callback_fn(/*? interrupt_struct_prefix ?*/_/*? i ?*/.callback_data, 
+                        /*? interrupt_struct_prefix ?*/_/*? i ?*/.callback_fn(/*? interrupt_struct_prefix ?*/_/*? i ?*/.callback_data,
 
                                                                               /*? me.interface.name ?*/_irq_acknowledge_wrapper,
 

--- a/camkes/templates/seL4DTBHardware-to.template.c
+++ b/camkes/templates/seL4DTBHardware-to.template.c
@@ -117,7 +117,7 @@
 
     /*# CAmkES has a maximum limit of 28 bits for badges, #*/
     /*# highly unlikely a device has greater than 28 #*/
-    /*? dtb_macros.parse_dtb_node_interrupts(dtb, 28) ?*/
+    /*? dtb_macros.parse_dtb_node_interrupts(dtb, 28, options.architecture) ?*/
     /*- set irq_set = pop('irq_set') -*/
 
     /*- for (i, irq_node) in enumerate(irq_set)  -*/


### PR DESCRIPTION
Seems on ARM this was always used with device trees that have 3 values per interrupt or extended interrupts that have just one interrupt. Fix the handling for extended interrupts to allow more than one. Add support for device trees (e.g. RISC-V HiFive) that use only one value per interrupt. This is a hack that add some smart guessing to accept them also. More documentation is also added about the problems. The long term fix should be properly parsing the device tree, as it is done in the kernel already.
