### PR TITLE
libsel4camkes,dma: Support different cache attribs

### DIFF
--- a/camkes/templates/component.common.c
+++ b/camkes/templates/component.common.c
@@ -164,6 +164,7 @@ char /*? dma_symbol_name ?*/[/*? dma_pool ?*/]
         .cap = /*? cap ?*/,
         .size = /*? page_size[0] ?*/,
         .vaddr = (uintptr_t) &/*? dma_symbol_name ?*/[/*? loop.index0 * page_size[0] ?*/],
+        .cached = /*? int(dma_pool_cache) ?*/,
     };
     USED SECTION("_dma_frames")
     dma_frame_t * /*? me.instance.name ?*/_dma_/*? loop.index0 ?*/_ptr = &/*? me.instance.name ?*/_dma_/*? loop.index0 ?*/;

--- a/camkes/templates/seL4DMASharedData.template.c
+++ b/camkes/templates/seL4DMASharedData.template.c
@@ -39,6 +39,7 @@
         .cap = /*? cap ?*/,
         .size = /*? page_size ?*/,
         .vaddr = (uintptr_t) &/*? dataport_symbol_name ?*/.content[/*? loop.index0 * page_size ?*/],
+        .cached = /*?  int(cached) ?*/,
     };
     USED SECTION("_dma_frames")
     dma_frame_t * /*? me.interface.name ?*/_dma_/*? loop.index0 ?*/_ptr = &/*? me.interface.name ?*/_dma_/*? loop.index0 ?*/;

--- a/libsel4camkes/include/camkes/dma.h
+++ b/libsel4camkes/include/camkes/dma.h
@@ -38,7 +38,7 @@ NONNULL(1) WARN_UNUSED_RESULT;
  *
  * @return Virtual address of allocation or NULL on failure
  */
-void *camkes_dma_alloc(size_t size, int align) ALLOC_SIZE(1) ALLOC_ALIGN(2)
+void *camkes_dma_alloc(size_t size, int align, bool cached) ALLOC_SIZE(1) ALLOC_ALIGN(2)
 MALLOC WARN_UNUSED_RESULT;
 
 /**
@@ -156,5 +156,6 @@ struct dma_frame {
     seL4_CPtr cap;
     size_t size;
     uintptr_t vaddr;
+    bool cached;
 };
 typedef struct dma_frame dma_frame_t;


### PR DESCRIPTION
Support registering DMA memory that is both cached and uncached and then return memory with correct cache attributes when alloc is called.

It's not clear what requires or depends on this change. Needs to have any merge conflicts resolved before it can be merged to master.