### PR TITLE
libsel4camkes: Set virtqueue size on creation

### DIFF
--- a/libsel4camkes/include/camkes/msgqueue_template.h
+++ b/libsel4camkes/include/camkes/msgqueue_template.h
@@ -23,6 +23,7 @@ typedef enum msgqueue_role {
 typedef struct camkes_msgqueue_channel {
     msgqueue_role_t role;
     void *buffer;
+    unsigned queue_len;
     size_t buffer_size;
     size_t message_size;
     union {
@@ -38,10 +39,10 @@ typedef struct camkes_msgqueue_channel {
     };
 } camkes_msgqueue_channel_t;
 
-int camkes_msgqueue_channel_register_sender(int msgqueue_id, void *buffer, size_t buffer_size,
+int camkes_msgqueue_channel_register_sender(int msgqueue_id, void *buffer, unsigned queue_len, size_t buffer_size,
                                             size_t message_size, void (*notify)(void));
 
-int camkes_msgqueue_channel_register_receiver(int msgqueue_id, void *buffer, size_t buffer_size,
+int camkes_msgqueue_channel_register_receiver(int msgqueue_id, void *buffer, unsigned queue_len, size_t buffer_size,
                                               size_t message_size, int (*poll)(void), void (*wait)(void));
 
 camkes_msgqueue_channel_t *camkes_msgqueue_channel_get(int msgqueue_id, msgqueue_role_t role);

--- a/libsel4camkes/include/camkes/virtqueue.h
+++ b/libsel4camkes/include/camkes/virtqueue.h
@@ -41,6 +41,7 @@ typedef enum virtqueue_role {
 typedef struct virtqueue_channel {
     volatile void *channel_buffer;
     size_t channel_buffer_size;
+    unsigned queue_len;
     void (*notify)(void);
     seL4_CPtr recv_notification;
     seL4_Word recv_badge;

--- a/libsel4camkes/include/camkes/virtqueue_template.h
+++ b/libsel4camkes/include/camkes/virtqueue_template.h
@@ -26,6 +26,6 @@
  * @param role The components role over the virtqueue channel (DEVICE or DRIVER)
  * @return Positive 0 on success, -1 on error
  */
-int camkes_virtqueue_channel_register(int virtqueue_id, const char *interface_name, size_t size, volatile void *buf,
-                                      void (*notify)(void),
+int camkes_virtqueue_channel_register(int virtqueue_id, const char *interface_name, unsigned queue_len, size_t size,
+									  volatile void *buf, void (*notify)(void),
                                       seL4_CPtr recv_notification, seL4_Word recv_badge, virtqueue_role_t role);

--- a/libsel4camkes/src/msgqueue.c
+++ b/libsel4camkes/src/msgqueue.c
@@ -48,7 +48,7 @@ int camkes_msgqueue_sender_init(int msgqueue_id, camkes_msgqueue_sender_t *sende
         aligned_message_size = NEXT_POWER_OF_2(msgqueue_channel->message_size);
     }
 
-    int error = camkes_virtqueue_driver_init_common(&sender->sender_channel, msgqueue_channel->buffer,
+    int error = camkes_virtqueue_driver_init_common(&sender->sender_channel, msgqueue_channel->buffer, msgqueue_channel->queue_len,
                                                     msgqueue_channel->buffer_size, msgqueue_channel->sender_funcs.notify,
                                                     aligned_message_size);
     if (error) {
@@ -79,7 +79,7 @@ int camkes_msgqueue_receiver_init(int msgqueue_id, camkes_msgqueue_receiver_t *r
     }
 
     int error = camkes_virtqueue_device_init_common(&receiver->receiver_channel,
-                                                    msgqueue_channel->buffer, NULL);
+                                                    msgqueue_channel->buffer, msgqueue_channel->queue_len, NULL);
     if (error) {
         return error;
     }

--- a/libsel4camkes/src/msgqueue_template.c
+++ b/libsel4camkes/src/msgqueue_template.c
@@ -48,19 +48,20 @@ static inline int msgqueue_channel_check_common(int msgqueue_id, void *buffer, s
     return 0;
 }
 
-static inline void msgqueue_channel_init_common(int msgqueue_id, void *buffer, size_t buffer_size,
-                                                size_t message_size)
+static inline void msgqueue_channel_init_common(int msgqueue_id, void *buffer, unsigned queue_len,
+                                                size_t buffer_size, size_t message_size)
 {
     camkes_msgqueue_channels[msgqueue_id] = (camkes_msgqueue_channel_t) {
         0
     };
     camkes_msgqueue_channels[msgqueue_id].buffer = buffer;
+    camkes_msgqueue_channels[msgqueue_id].queue_len = queue_len;
     camkes_msgqueue_channels[msgqueue_id].buffer_size = buffer_size;
     camkes_msgqueue_channels[msgqueue_id].message_size = message_size;
 }
 
-int camkes_msgqueue_channel_register_sender(int msgqueue_id, void *buffer, size_t buffer_size,
-                                            size_t message_size, void (*notify)(void))
+int camkes_msgqueue_channel_register_sender(int msgqueue_id, void *buffer, unsigned queue_len,
+                                            size_t buffer_size, size_t message_size, void (*notify)(void))
 {
     int res = msgqueue_channel_check_common(msgqueue_id, buffer, buffer_size, message_size);
     if (res) {
@@ -72,7 +73,7 @@ int camkes_msgqueue_channel_register_sender(int msgqueue_id, void *buffer, size_
         return -EINVAL;
     }
 
-    msgqueue_channel_init_common(msgqueue_id, buffer, buffer_size, message_size);
+    msgqueue_channel_init_common(msgqueue_id, buffer, queue_len, buffer_size, message_size);
 
     camkes_msgqueue_channels[msgqueue_id].role = MSGQUEUE_SENDER;
     camkes_msgqueue_channels[msgqueue_id].sender_funcs.notify = notify;
@@ -80,8 +81,8 @@ int camkes_msgqueue_channel_register_sender(int msgqueue_id, void *buffer, size_
     return 0;
 }
 
-int camkes_msgqueue_channel_register_receiver(int msgqueue_id, void *buffer, size_t buffer_size,
-                                              size_t message_size, int (*poll)(void), void (*wait)(void))
+int camkes_msgqueue_channel_register_receiver(int msgqueue_id, void *buffer, unsigned queue_len,
+                                              size_t buffer_size, size_t message_size, int (*poll)(void), void (*wait)(void))
 {
     int res = msgqueue_channel_check_common(msgqueue_id, buffer, buffer_size, message_size);
     if (res) {
@@ -93,7 +94,7 @@ int camkes_msgqueue_channel_register_receiver(int msgqueue_id, void *buffer, siz
         return -EINVAL;
     }
 
-    msgqueue_channel_init_common(msgqueue_id, buffer, buffer_size, message_size);
+    msgqueue_channel_init_common(msgqueue_id, buffer, queue_len, buffer_size, message_size);
 
     camkes_msgqueue_channels[msgqueue_id].role = MSGQUEUE_RECEIVER;
     camkes_msgqueue_channels[msgqueue_id].receiver_funcs.poll = poll;

--- a/libsel4camkes/src/virtqueue.c
+++ b/libsel4camkes/src/virtqueue.c
@@ -116,7 +116,7 @@ int camkes_virtqueue_driver_init_with_recv(virtqueue_driver_t *driver, unsigned 
         *recv_badge = channel->recv_badge;
     }
 
-    return camkes_virtqueue_driver_init_common(driver, channel->channel_buffer, channel->channel_buffer_size,
+    return camkes_virtqueue_driver_init_common(driver, channel->channel_buffer, channel->queue_len, channel->channel_buffer_size,
                                                channel->notify, BLOCK_SIZE) ? -1 : 0;
 }
 
@@ -140,7 +140,7 @@ int camkes_virtqueue_device_init_with_recv(virtqueue_device_t *device, unsigned 
         *recv_badge = channel->recv_badge;
     }
 
-    return camkes_virtqueue_device_init_common(device, channel->channel_buffer, channel->notify) ? -1 : 0;
+    return camkes_virtqueue_device_init_common(device, channel->channel_buffer, channel->queue_len, channel->notify) ? -1 : 0;
 }
 
 void *camkes_virtqueue_device_offset_to_buffer(virtqueue_device_t *virtqueue, uintptr_t offset)

--- a/libsel4camkes/src/virtqueue_common.h
+++ b/libsel4camkes/src/virtqueue_common.h
@@ -26,7 +26,8 @@ struct vq_buf_alloc {
 
 struct vq_buf_alloc *init_vq_allocator(void *mem_pool, unsigned len, size_t block_size);
 
-int camkes_virtqueue_driver_init_common(virtqueue_driver_t *driver, volatile void *buffer, size_t buffer_size,
-                                        void (*notify)(void), size_t block_size);
+int camkes_virtqueue_driver_init_common(virtqueue_driver_t *driver, volatile void *buffer, unsigned queue_len,
+									    size_t buffer_size, void (*notify)(void), size_t block_size);
 
-int camkes_virtqueue_device_init_common(virtqueue_device_t *device, volatile void *buffer, void (*notify)(void));
+int camkes_virtqueue_device_init_common(virtqueue_device_t *device, volatile void *buffer, unsigned queue_len,
+									    void (*notify)(void));

--- a/libsel4camkes/src/virtqueue_template.c
+++ b/libsel4camkes/src/virtqueue_template.c
@@ -16,8 +16,8 @@
 camkes_virtqueue_channel_t camkes_virtqueue_channels[MAX_CAMKES_VIRTQUEUE_ID + 1];
 int num_registered_virtqueue_channels = 0;
 
-int camkes_virtqueue_channel_register(int virtqueue_id, const char *interface_name, size_t size, volatile void *buf,
-                                      void (*notify)(void),
+int camkes_virtqueue_channel_register(int virtqueue_id, const char *interface_name, unsigned queue_len, size_t size,
+                                      volatile void *buf, void (*notify)(void),
                                       seL4_CPtr recv_notification, seL4_Word recv_badge, virtqueue_role_t role)
 {
     /* Check that the virtqueue_id is in range */
@@ -32,6 +32,7 @@ int camkes_virtqueue_channel_register(int virtqueue_id, const char *interface_na
     camkes_virtqueue_channel_t *vq_channel = &camkes_virtqueue_channels[virtqueue_id];
     vq_channel->channel_buffer = buf;
     vq_channel->channel_buffer_size = size;
+    vq_channel->queue_len = queue_len;
     vq_channel->notify = notify;
     vq_channel->recv_notification = recv_notification;
     vq_channel->recv_badge = recv_badge;


### PR DESCRIPTION
The queue size of a virtqueue is how many entries its rings and descriptor table have.

It's not clear what requires or depends on this change. Needs to have any merge conflicts resolved before it can be merged to master.