### PR TITLE
camkes-gen.cmake: best-effort build step can error

### DIFF
--- a/camkes/templates/camkes-gen.cmake
+++ b/camkes/templates/camkes-gen.cmake
@@ -446,7 +446,7 @@ RequireFile(CONFIGURE_FILE_SCRIPT configure_file.cmake PATHS ${CMAKE_MODULE_PATH
             # architecture that requires `.eh_frame`.
             bash -c "${OBJCOPY} --remove-section .eh_frame --remove-section .eh_frame_hdr \
                 --remove-section .rel.eh_frame --remove-section .rela.eh_frame ${output} \
-                >/dev/null 2>/dev/null"
+                >/dev/null 2>/dev/null || true"
         VERBATIM
         DEPENDS ${input_target}
     )


### PR DESCRIPTION
When linking multiple components together to create a "grouped"
component we run some objcopy commands to remove unsupported and unused
sections such as the .eh_frame.  Some toolchains don't allow this and
cause objcopy to error but this shouldn't cause the build step to fail.
The build rule was already trying to catch the error according to its
preceding comment, but now it does this correctly.

Signed-off-by: Kent McLeod <kent@kry10.com>