### PR TITLE
CAmkES hardware tests + deployment

### DIFF
--- a/.github/workflows/camkes-deploy.yml
+++ b/.github/workflows/camkes-deploy.yml
@@ -1,0 +1,121 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# CAmkES regression tests
+
+name: CAmkES
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - '**.md'
+
+  # allow manual trigger
+  workflow_dispatch:
+
+  # allow explict trigger from other repos when dependencies have changed
+  repository_dispatch:
+    types: [deps-update]
+
+jobs:
+  code:
+    name: Freeze Code
+    runs-on: ubuntu-latest
+    outputs:
+      xml: ${{ steps.repo.outputs.xml }}
+    steps:
+    - id: repo
+      uses: seL4/ci-actions/repo-checkout@master
+      with:
+        manifest_repo: camkes-manifest
+        manifest: master.xml
+
+  build:
+    name: Build
+    needs: code
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+            # - ODROID_XU
+            - ODROID_XU4
+            - PC99
+            # - TX1
+            - TX2
+            - IMX8MM_EVK
+            # - IMX8MQ_EVK
+    steps:
+    - uses: seL4/ci-actions/camkes-test@master
+      with:
+        xml: ${{ needs.code.outputs.xml }}
+        platform: ${{ matrix.platform }}
+    - name: Upload images
+      uses: actions/upload-artifact@v2
+      with:
+        name: images-${{ matrix.platform }}
+        path: '*-images.tar.gz'
+
+  sim:
+    name: Simulate
+    needs: code
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [sim]
+        name: [sabre, ia32, x86_64, cakeml_1, cakeml_2, spike64_1, spike64_2]
+    steps:
+    - uses: seL4/ci-actions/camkes-test@master
+      with:
+        xml: ${{ needs.code.outputs.xml }}
+        platform: ${{ matrix.platform }}
+        name: ${{ matrix.name }}
+
+  hw-run:
+    name: Hardware
+    runs-on: ubuntu-latest
+    needs: [build] # , sim]
+    strategy:
+      matrix:
+        platform:
+            # - ODROID_XU
+            - ODROID_XU4
+            - PC99
+            # - TX1
+            - TX2
+            - IMX8MM_EVK
+            # - IMX8MQ_EVK
+    # do not run concurrently with other workflows, but do run concurrently in the build matrix
+    concurrency: camkes-hw-${{ strategy.job-index }}
+    steps:
+      - name: Get machine queue
+        uses: actions/checkout@v2
+        with:
+          repository: seL4/machine_queue
+          path: machine_queue
+          token: ${{ secrets.PRIV_REPO_TOKEN }}
+      - name: Download image
+        uses: actions/download-artifact@v2
+        with:
+          name: images-${{ matrix.platform }}
+      - name: Run
+        uses: seL4/ci-actions/camkes-hw@master
+        with:
+          platform: ${{ matrix.platform }}
+          index: $${{ strategy.job-index }}
+        env:
+          HW_SSH: ${{ secrets.HW_SSH }}
+
+  deploy:
+    name: Deploy manifest
+    runs-on: ubuntu-latest
+    needs: [code, hw-run]
+    steps:
+    - name: Deploy
+      uses: seL4/ci-actions/manifest-deploy@master
+      with:
+        xml: ${{ needs.code.outputs.xml }}
+        manifest_repo: camkes-manifest
+      env:
+        GH_SSH: ${{ secrets.CI_SSH }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-# CAmkES unit tests
+# CAmkES regression tests
 
 name: CAmkES
 
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    name: Test
+    name: Build + Simulate
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,6 @@
 name: CAmkES
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
This workflow runs simulation + HW builds + HW tests on push to master or on repository dispatch messages, and deploys to camkes-manifest when all of these pass.

The corresponding CI action PR is at seL4/ci-actions#152