### PR TITLE
 parser: fix attribute_reference regex 

### DIFF
--- a/camkes/parser/camkes.g
+++ b/camkes/parser/camkes.g
@@ -213,7 +213,7 @@ bitwise_not: '~' precedence0;
 number: '(0x[0-9a-fA-F]+|\d+(\.\d+)?)';
 multi_string: quoted_string+;
 quoted_string: '"[^"]*"'; // "
-angle_string: '<[^>]*>';
+angle_string: '<[^<>;,"{}]*>';
 list: '\[' (item (',' item)* ','?)? '\]';
 dict: '\{' (key ':' item (',' key ':' item)* ','?)? '\}';
 dict_lookup: ('\[' key '\]')+;


### PR DESCRIPTION
The lexxer showed syntax errors when working with attribute references
using '<-'. The regular expression for angle_string is being checked by
the lexxer when encountering the '<' first.
So if the file to be parsed contains a '>' following the attribute
reference, the lexxer will tokenize everything from '<-' to this '>',
leading to a syntax error.
Examples for this behaviour would be an import statement with angled
brackes or an export statement containing '->'.
The proposed fix adds further characters to be excluded in the regular
expression, to avoid the angle_string rule to be active in such cases.

Signed-off-by: Thomas Wittal <thomas.wittal@hensoldt-cyber.de>