### PR TITLE
Remove references to kzm platform

### DIFF
--- a/cdl-refine-tests/run_tests
+++ b/cdl-refine-tests/run_tests
@@ -124,7 +124,6 @@ override_app_platform = {
     'serialserver_interrupt': 'exynos5410',
     'serialserver_polling': 'exynos5410',
     'serialserver_loopback': 'exynos5410',
-    'uart': 'kzm',
 }
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -325,13 +325,13 @@ echo and client, communicating over a single interface.
 To build this example, from the top-level directory run:
 
 ```bash
-mkdir build-kzm
-cd build-kzm
-../init-build.sh -DPLATFORM=kzm -DCROSS_COMPILER_PREFIX=arm-none-eabi- -DCAMKES_APP=simple -DSIMULATE=1
+mkdir build
+cd build
+../init-build.sh -DPLATFORM=sabre -DCAMKES_APP=simple -DSIMULATE=1
 ninja
 ```
 
-This produces an image images/simple-image-arm-imx31. To run this image in
+This produces an image images/capdl-loader-image-arm-imx6. To run this image in
 qemu:
 
 ```bash
@@ -515,7 +515,7 @@ DeclareCAmkESRootserver(helloworld.camkes)
 You're now ready to compile and run this application, by entering the `CAMKES_APP` value in the cmake configuration GUI:
 
 ```bash
-cd build-kzm
+cd build
 cmake . -DCAMKES_APP=helloworld # set `helloworld` as CAMKES_APP
 ninja
 ./simulate

--- a/libsel4camkes/src/sys_uname.c
+++ b/libsel4camkes/src/sys_uname.c
@@ -56,9 +56,7 @@ long camkes_sys_uname(va_list ap)
 
 #if defined(CONFIG_ARCH_ARM)
     arch = "ARM";
-#if defined(CONFIG_ARCH_ARM_V6)
-    arch_ver = "v6";
-#elif defined(CONFIG_ARCH_ARM_V7A)
+#if defined(CONFIG_ARCH_ARM_V7A)
     arch_ver = "v7a";
 #elif defined(CONFIG_ARCH_ARM_V7VE)
     arch_ver = "v7a-ve";


### PR DESCRIPTION
This platform has been removed from seL4 due to ending support. The
sabre platform should be substitutable for camkes examples.

See: seL4/seL4#578