### PR TITLE
github: run on hw only after successful simulation

### DIFF
--- a/.github/workflows/camkes-deploy.yml
+++ b/.github/workflows/camkes-deploy.yml
@@ -75,7 +75,7 @@ jobs:
   hw-run:
     name: Hardware
     runs-on: ubuntu-latest
-    needs: [build] # , sim]
+    needs: [build, sim]
     strategy:
       matrix:
         platform:


### PR DESCRIPTION
The dependency of the hardware job on simulation successs was still commented out for testing.
