### PR TITLE
camkes: Remove unused python library

### DIFF
--- a/camkes/runner/__main__.py
+++ b/camkes/runner/__main__.py
@@ -27,7 +27,6 @@ from capdl.Allocator import RenderState
 from camkes.internal.exception import CAmkESError
 import camkes.internal.log as log
 from camkes.templates import TemplateError
-from simpleeval import simple_eval
 
 import yaml
 


### PR DESCRIPTION
Library no longer used in camkes