### PR TITLE
github: run camkes-vm-examples build on PR

### DIFF
--- a/.github/workflows/vm-test.yml
+++ b/.github/workflows/vm-test.yml
@@ -1,0 +1,23 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Actions to run on pull requests
+
+name: Camkes VM Examples
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        march: [nehalem, armv7a, armv8a]
+    steps:
+    - uses: seL4/ci-actions/camkes-vm@master
+      with:
+        march: ${{ matrix.march }}


### PR DESCRIPTION
The `vm-examples` build also includes a simulation run for `ARMVIRT`, so this should give at least an indication if things are working.

The full hardware test will run in the `camkes-vm-examples` repo after merge/push to master in `camkes-tool` or other components of `camkes-vm-examples-manifest`.
