### PR TITLE
SMC Capability

### DIFF
--- a/camkes/templates/component.common.c
+++ b/camkes/templates/component.common.c
@@ -89,19 +89,13 @@ seL4_CPtr camkes_get_smc_cap(seL4_Word smc_call){
     seL4_CPtr cap;
     switch(smc_call) {
 /*# ARM SMC cap allocation #*/
-/*- if 'allow_smc' in configuration[me.name].keys() -*/
-    /*- if configuration[me.name].get('allow_smc') == true -*/
-        /*- if 'allowed_smc_functions' in configuration[me.name].keys() -*/
-            /*- for func_id in configuration[me.name].allowed_smc_functions -*/
-                /*- set smc_cap = alloc(name='smc_%d' % func_id, type=seL4_ARMSMC, badge=func_id) -*/
+/*- for func_id in configuration[me.name].get('allowed_smc_functions', []) -*/
+    /*- set smc_cap = alloc(name='smc_%d' % func_id, type=seL4_ARMSMC, badge=func_id) -*/
 
         case /*? func_id ?*/:
             cap = /*? smc_cap ?*/;
             break;
-            /*- endfor -*/
-        /*- endif -*/
-    /*- endif -*/
-/*- endif -*/
+/*- endfor -*/
         default:
             cap = 0;
     }

--- a/camkes/templates/component.common.c
+++ b/camkes/templates/component.common.c
@@ -84,6 +84,23 @@ int get_instance_affinity(void) {
     return /*? configuration[me.name].get('affinity', options.default_affinity) ?*/;
 }
 
+#ifdef CONFIG_ALLOW_SMC_CALLS
+/*# ARM SMC cap allocation #*/
+/*- if 'allow_smc' in configuration[me.name].keys() -*/
+    /*- if configuration[me.name].get('allow_smc') == true -*/
+        /*- set smc_cap = alloc(name='smc', type=seL4_ARMSMC) -*/
+    /*- else -*/
+        /*- set smc_cap = 0 -*/
+    /*- endif -*/
+/*- else -*/
+    /*- set smc_cap = 0 -*/
+/*- endif -*/
+
+seL4_CPtr camkes_get_smc_cap(){
+    return /*? smc_cap ?*/;
+}
+#endif
+
 /*- set cnode_size = configuration[me.address_space].get('cnode_size_bits') -*/
 /*- if cnode_size -*/
         /*- if isinstance(cnode_size, six.string_types) -*/

--- a/camkes/templates/component.common.c
+++ b/camkes/templates/component.common.c
@@ -85,19 +85,27 @@ int get_instance_affinity(void) {
 }
 
 #ifdef CONFIG_ALLOW_SMC_CALLS
+seL4_CPtr camkes_get_smc_cap(seL4_Word smc_call){
+    seL4_CPtr cap;
+    switch(smc_call) {
 /*# ARM SMC cap allocation #*/
 /*- if 'allow_smc' in configuration[me.name].keys() -*/
     /*- if configuration[me.name].get('allow_smc') == true -*/
-        /*- set smc_cap = alloc(name='smc', type=seL4_ARMSMC) -*/
-    /*- else -*/
-        /*- set smc_cap = 0 -*/
-    /*- endif -*/
-/*- else -*/
-    /*- set smc_cap = 0 -*/
-/*- endif -*/
+        /*- if 'allowed_smc_functions' in configuration[me.name].keys() -*/
+            /*- for func_id in configuration[me.name].allowed_smc_functions -*/
+                /*- set smc_cap = alloc(name='smc_%d' % func_id, type=seL4_ARMSMC, badge=func_id) -*/
 
-seL4_CPtr camkes_get_smc_cap(){
-    return /*? smc_cap ?*/;
+        case /*? func_id ?*/:
+            cap = /*? smc_cap ?*/;
+            break;
+            /*- endfor -*/
+        /*- endif -*/
+    /*- endif -*/
+/*- endif -*/
+        default:
+            cap = 0;
+    }
+    return cap;
 }
 #endif
 


### PR DESCRIPTION
Add a new capability which certain threads can invoke so seL4 can make SMC calls on ARM platforms in EL2 (virtualized mode) on the thread’s behalf.

See https://sel4.atlassian.net/browse/RFC-9
