### PR TITLE
trivial: Fix Python3 collections

### DIFF
--- a/camkes/ast/base.py
+++ b/camkes/ast/base.py
@@ -229,7 +229,7 @@ class ASTObject(six.with_metaclass(abc.ABCMeta, object)):
         return None
 
 
-class MapLike(six.with_metaclass(abc.ABCMeta, ASTObject, collections.Mapping)):
+class MapLike(six.with_metaclass(abc.ABCMeta, ASTObject, collections.abc.Mapping)):
 
     no_hash = ASTObject.no_hash + ('_mapping',)
 

--- a/camkes/ast/base.py
+++ b/camkes/ast/base.py
@@ -14,7 +14,10 @@ from camkes.internal.hash import camkes_hash
 from .exception import ASTError
 from .location import SourceLocation
 from .traversal import NullContext, TraversalAction, TraversalContext
-import abc, collections, six
+import abc
+import collections
+import six
+
 
 class ASTObject(six.with_metaclass(abc.ABCMeta, object)):
 
@@ -34,6 +37,7 @@ class ASTObject(six.with_metaclass(abc.ABCMeta, object)):
     @property
     def frozen(self):
         return self._frozen
+
     @frozen.setter
     def frozen(self, value):
         assert isinstance(value, bool)
@@ -44,23 +48,25 @@ class ASTObject(six.with_metaclass(abc.ABCMeta, object)):
     @property
     def location(self):
         return self._location
+
     @location.setter
     def location(self, value):
         assert value is None or isinstance(value, SourceLocation)
         if self.frozen:
             raise TypeError('you cannot change the location of a frozen AST '
-                'object')
+                            'object')
         self._location = value
 
     @property
     def parent(self):
         return self._parent
+
     @parent.setter
     def parent(self, value):
         assert value is None or isinstance(value, ASTObject)
         if self.frozen:
             raise TypeError('you cannot change the parent of a frozen AST '
-                'object')
+                            'object')
         self._parent = value
 
     def freeze(self):
@@ -124,7 +130,7 @@ class ASTObject(six.with_metaclass(abc.ABCMeta, object)):
             elif getattr(self, f) != getattr(other, f):
                 if type(getattr(self, f)) != type(getattr(other, f)):
                     return cmp(str(type(getattr(self, f))),
-                        str(type(getattr(other, f))))
+                               str(type(getattr(other, f))))
                 elif isinstance(getattr(self, f), type):
                     assert isinstance(getattr(other, f), type), 'incorrect ' \
                         'control flow in __cmp__ (bug in AST base?)'
@@ -135,7 +141,7 @@ class ASTObject(six.with_metaclass(abc.ABCMeta, object)):
 
     def __hash__(self):
         return camkes_hash((k, v) for k, v in self.__dict__.items()
-                if k not in self.no_hash)
+                           if k not in self.no_hash)
 
     # When comparing `ASTObject`s, we always want to invoke
     # `ASTObject.__cmp__`, but unfortunately we inherit rich comparison methods
@@ -144,14 +150,19 @@ class ASTObject(six.with_metaclass(abc.ABCMeta, object)):
     # infinitely recurse.
     def __lt__(self, other):
         return self.__cmp__(other) < 0
+
     def __le__(self, other):
         return self.__cmp__(other) <= 0
+
     def __eq__(self, other):
         return self.__cmp__(other) == 0
+
     def __ne__(self, other):
         return self.__cmp__(other) != 0
+
     def __gt__(self, other):
         return self.__cmp__(other) > 0
+
     def __ge__(self, other):
         return self.__cmp__(other) >= 0
 
@@ -217,6 +228,7 @@ class ASTObject(six.with_metaclass(abc.ABCMeta, object)):
     def label(self):
         return None
 
+
 class MapLike(six.with_metaclass(abc.ABCMeta, ASTObject, collections.Mapping)):
 
     no_hash = ASTObject.no_hash + ('_mapping',)
@@ -230,13 +242,15 @@ class MapLike(six.with_metaclass(abc.ABCMeta, ASTObject, collections.Mapping)):
             return
         super(MapLike, self).freeze()
         self._mapping = {}
+
         def add(d, i):
             duplicate = d.get(i.name)
             if duplicate is not None:
                 raise ASTError('duplicate entity \'%s\' defined, '
-                    'collides with %s at %s:%s' % (i.name,
-                    type(duplicate).__name__, duplicate.filename,
-                    duplicate.lineno), i)
+                               'collides with %s at %s:%s' % (i.name,
+                                                              type(
+                                                                  duplicate).__name__, duplicate.filename,
+                                                              duplicate.lineno), i)
             d[i.name] = i
         for field in self.child_fields:
             assert hasattr(self, field)
@@ -251,9 +265,11 @@ class MapLike(six.with_metaclass(abc.ABCMeta, ASTObject, collections.Mapping)):
     def __getitem__(self, key):
         assert self.frozen, 'dict access on non-frozen object'
         return self._mapping[key]
+
     def __iter__(self):
         assert self.frozen, 'dict access on non-frozen object'
         return iter(self._mapping)
+
     def __len__(self):
         assert self.frozen, 'dict access on non-frozen object'
         return len(self._mapping)

--- a/camkes/ast/liftedast.py
+++ b/camkes/ast/liftedast.py
@@ -59,7 +59,8 @@ class LiftedAST(ASTObject, collections.Iterable):
 
     def filter(self, function=None):
         if function is None:
-            function = lambda x: x is not None
+            def local_function(x): return x is not None
+            function = local_function
         self.items = [x for x in self.items if function(x)]
 
     def __iter__(self):

--- a/camkes/ast/liftedast.py
+++ b/camkes/ast/liftedast.py
@@ -16,7 +16,7 @@ from .traversal import TraversalAction
 import collections
 
 
-class LiftedAST(ASTObject, collections.Iterable):
+class LiftedAST(ASTObject, collections.abc.Iterable):
     child_fields = ('items',)
 
     no_hash = ASTObject.no_hash + ('_assembly',)

--- a/camkes/ast/liftedast.py
+++ b/camkes/ast/liftedast.py
@@ -15,6 +15,7 @@ from .objects import Assembly
 from .traversal import TraversalAction
 import collections
 
+
 class LiftedAST(ASTObject, collections.Iterable):
     child_fields = ('items',)
 
@@ -30,12 +31,13 @@ class LiftedAST(ASTObject, collections.Iterable):
     @property
     def items(self):
         return self._items
+
     @items.setter
     def items(self, value):
         assert isinstance(value, (list, tuple))
         if self.frozen:
             raise TypeError('you cannot change the items in a frozen lifted '
-                'AST')
+                            'AST')
         self._items = value
 
     def freeze(self):
@@ -64,6 +66,7 @@ class LiftedAST(ASTObject, collections.Iterable):
         c = Collector()
         self.postorder(c)
         return iter(c.contents)
+
 
 class Collector(TraversalAction):
     def __init__(self):

--- a/camkes/internal/frozendict.py
+++ b/camkes/internal/frozendict.py
@@ -17,6 +17,7 @@ from camkes.internal.seven import cmp, filter, map, zip
 
 import collections
 
+
 class frozendict(collections.Mapping):
     def __init__(self, dictionary=None):
         self._d = dictionary or {}

--- a/camkes/internal/frozendict.py
+++ b/camkes/internal/frozendict.py
@@ -18,7 +18,7 @@ from camkes.internal.seven import cmp, filter, map, zip
 import collections
 
 
-class frozendict(collections.Mapping):
+class frozendict(collections.abc.Mapping):
     def __init__(self, dictionary=None):
         self._d = dictionary or {}
 

--- a/camkes/internal/hash.py
+++ b/camkes/internal/hash.py
@@ -50,15 +50,15 @@ def camkes_hash(value):
         # for them before checking for Hashable as they
         # must be hashed differently.
         return hash_iterable(value)
-    elif isinstance(value, collections.Hashable):
+    elif isinstance(value, collections.abc.Hashable):
         # Some camkes ast objects have a Mapping interface,
         # but are also hashable, and should be hashed normally.
         # This case also catches general hashable types (e.g. int).
         return hash(value)
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections.abc.Mapping):
         # Dicts and other Mappings that aren't hashable
         return hash_mapping(value)
-    elif isinstance(value, collections.Iterable):
+    elif isinstance(value, collections.abc.Iterable):
         # Lists and other iterables that aren't hashable
         return hash_iterable(value)
     else:

--- a/camkes/internal/hash.py
+++ b/camkes/internal/hash.py
@@ -17,12 +17,16 @@ hash strings.
 '''
 
 from camkes.internal.strhash import strhash
-import six, types, collections
+import six
+import types
+import collections
 
 INITIAL_HASH_VALUE = 0x345678
 
+
 def hash_extend(current, extra):
     return (current ^ extra) * 1000003
+
 
 def camkes_hash(value):
     '''
@@ -60,11 +64,13 @@ def camkes_hash(value):
     else:
         raise ValueError("Unexpected value: %s" % value)
 
+
 def hash_iterable(i):
     h = INITIAL_HASH_VALUE
     for v in i:
         h = hash_extend(h, camkes_hash(v))
     return h
+
 
 def hash_mapping(m):
     h = INITIAL_HASH_VALUE


### PR DESCRIPTION
1. collections.Mapping, collections.Hashable, collections.Iterable, etc are deprecated in Python3.3, removed in Python3.10. Ref to: [collections.abc](https://docs.python.org/3/library/collections.abc.html)
2. Fix style for Python3 style check

Signed-off-by: Homalozoa <xuhaiwang@xiaomi.com>