### PR TITLE
Name frames in a region for easy sorting

### DIFF
--- a/camkes/runner/Context.py
+++ b/camkes/runner/Context.py
@@ -563,7 +563,6 @@ def register_fill_frame(addr_space, symbol, fill, size, obj_space, label):
         fill_str = ['%d %d %s %d' % (0, 4096 if (size - (i * 4096)) >=
                                      4096 else (size - (i * 4096)), fill, i * 4096)]
         name = namefmt % (symbol, label, i)
-        
         frames.append(obj_space.alloc(ObjectType.seL4_FrameObject,
                                       name=name, label=label, fill=fill_str, size=4096))
     caps = [Cap(frame, read=True, write=False, grant=False) for frame in frames]

--- a/camkes/runner/Context.py
+++ b/camkes/runner/Context.py
@@ -557,7 +557,7 @@ def register_fill_frame(addr_space, symbol, fill, size, obj_space, label):
     assert addr_space
     number_frames = size//4096
     digits = str(int(log10(number_frames + 1)) + 1)
-    namefmt =  '%s_%s_%0' + digits + 'd_obj'
+    namefmt = '%s_%s_%0' + digits + 'd_obj'
     frames = []
     for i in range(number_frames):
         fill_str = ['%d %d %s %d' % (0, 4096 if (size - (i * 4096)) >=

--- a/camkes/runner/Context.py
+++ b/camkes/runner/Context.py
@@ -540,8 +540,9 @@ def get_shared_variable_backing_frames(obj_space, global_name, size, frame_size=
     frame_size = calc_frame_size(size, frame_size, obj_space.spec.arch)
     num_frames = size//frame_size
     digits = str(int(log10(num_frames + 1)) + 1)
+    namefmt = '%s_%0' + digits + 'd_obj'
     return [obj_space.alloc(ObjectType.seL4_FrameObject,
-                            name='%s_%0' + digits + 'd_obj' % (global_name, i),
+                            name=namefmt % (global_name, i),
                             size=frame_size,
                             label=label)
             for i in range(num_frames)]

--- a/camkes/runner/Context.py
+++ b/camkes/runner/Context.py
@@ -28,6 +28,7 @@ import inspect
 import itertools
 import functools
 import numbers
+from math import log10
 import \
     orderedset, os, pdb, re, six, sys, textwrap, math
 from capdl.Object import ObjectType, ObjectRights, ARMIRQMode
@@ -485,11 +486,12 @@ def register_shared_variable(addr_space, obj_space, global_name, symbol, size, c
     size = int(size)
     frame_size = calc_frame_size(size, frame_size, obj_space.spec.arch)
     num_frames = size//frame_size
-
+    digits = str(int(log10(num_frames + 1)) + 1)
+    namefmt = '%s_%0' + digits + 'd_obj'
     # If these frames have been allocated already then the allocator will return them.
     # Therefore calls to register_shared_variable with the same global_name have to have the same size.
     frames = [obj_space.alloc(ObjectType.seL4_FrameObject,
-                              name='%s_%d_obj' % (global_name, i),
+                              name=namefmt % (global_name, i),
                               size=frame_size,
                               label=label)
               for i in range(num_frames)]
@@ -537,8 +539,9 @@ def get_shared_variable_backing_frames(obj_space, global_name, size, frame_size=
     size = int(size)
     frame_size = calc_frame_size(size, frame_size, obj_space.spec.arch)
     num_frames = size//frame_size
+    digits = str(int(log10(num_frames + 1)) + 1)
     return [obj_space.alloc(ObjectType.seL4_FrameObject,
-                            name='%s_%d_obj' % (global_name, i),
+                            name='%s_%0' + digits + 'd_obj' % (global_name, i),
                             size=frame_size,
                             label=label)
             for i in range(num_frames)]
@@ -553,11 +556,14 @@ def register_fill_frame(addr_space, symbol, fill, size, obj_space, label):
     '''
     assert addr_space
     number_frames = size//4096
+    digits = str(int(log10(number_frames + 1)) + 1)
+    namefmt =  '%s_%s_%0' + digits + 'd_obj'
     frames = []
     for i in range(number_frames):
         fill_str = ['%d %d %s %d' % (0, 4096 if (size - (i * 4096)) >=
                                      4096 else (size - (i * 4096)), fill, i * 4096)]
-        name = '%s_%s_%d_obj' % (symbol, label, i)
+        name = namefmt % (symbol, label, i)
+        
         frames.append(obj_space.alloc(ObjectType.seL4_FrameObject,
                                       name=name, label=label, fill=fill_str, size=4096))
     caps = [Cap(frame, read=True, write=False, grant=False) for frame in frames]
@@ -576,7 +582,9 @@ def register_stack_symbol(addr_space, symbol, size, obj_space, label):
     '''
     assert addr_space
     number_frames = size//4096
-    frames = [obj_space.alloc(ObjectType.seL4_FrameObject, name='stack_%s_%d_%s_obj' % (symbol, i, label), label=label, size=4096)
+    digits = str(int(log10(number_frames + 1)) + 1)
+    namefmt = 'stack_%s_%0' + digits + 'd_%s_obj'
+    frames = [obj_space.alloc(ObjectType.seL4_FrameObject, name=namefmt % (symbol, i, label), label=label, size=4096)
               for i in range(number_frames)]
     # We create 2 additional mappings with None caps that are for the guard pages.
     sizes = [4096] * (number_frames + 2)


### PR DESCRIPTION
When generating a set of frames to cover a region, use as many digits
as necessary so that the capdl tool, when it sorts alphabetically,
will still leave frames that are meant to be contiguous contiguous.

Without this change, we had
 vm0_dma_1_obj
 vm0_dma_10_obj
 vm0_dma_11_obj
 ...
 vm0_dma_19_obj
 vm0_dma_2_obj
 vm0_dma_20_obj

etc; with the change we see
 vm0_dma_01_obj
 vm0_dma_02_obj
 ...

Signed-off-by: Peter Chubb <peter.chubb@unsw.edu.au>