### PR TITLE
CMake: add missing parameter DTB_FILE_PATH

### DIFF
--- a/camkes.cmake
+++ b/camkes.cmake
@@ -407,7 +407,7 @@ function(DeclareCAmkESRootserver adl)
         ${CAmkESDTS}
         AND
             NOT
-            "${CAMKES_ROOT_DTS_FILE}"
+            "${CAMKES_ROOT_DTS_FILE_PATH}"
             STREQUAL
             ""
     )


### PR DESCRIPTION
The CMake code seems to support passing a DTB also, but it's not exposed for the function parameter parsing. Is there are reason for it (besides nobody using this) or is this just missing?