### PR TITLE
Replace orderedset with ordered_set

### DIFF
--- a/camkes/runner/Context.py
+++ b/camkes/runner/Context.py
@@ -30,7 +30,7 @@ import functools
 import numbers
 from math import log10
 import \
-    orderedset, os, pdb, re, six, sys, textwrap, math
+    ordered_set, os, pdb, re, six, sys, textwrap, math
 from capdl.Object import ObjectType, ObjectRights, ARMIRQMode
 from capdl.Allocator import Cap
 from capdl import page_sizes
@@ -170,7 +170,7 @@ def new_context(entity, assembly, render_state, state_key, outfile_name,
                 'raise': _raise,
                 're': re,
                 'six': six,
-                'set': orderedset.OrderedSet,
+                'set': ordered_set.OrderedSet,
                 'textwrap': textwrap,
                 'copy': copy,
                 'zip': zip,

--- a/tools/check_deps.py
+++ b/tools/check_deps.py
@@ -157,7 +157,7 @@ DEPENDENCIES = {
                       PythonModule('plyplus', 'Python parsing module'),
                       PythonModule('ply', 'Python parsing module'),
                       PythonModule('elftools', 'Python ELF parsing module'),
-                      PythonModule('orderedset', 'Python OrderedSet module (orderedset)'),
+                      PythonModule('ordered_set', 'Python OrderedSet module (orderedset)'),
                       PythonModuleWith('six', 'Python 2/3 compatibility layer', 'assertCountEqual'),
                       PythonModule('sqlite3', 'Python SQLite module'),
                       PythonModule('pyfdt', 'Python flattened device tree parser')),

--- a/tools/python-deps/setup.py
+++ b/tools/python-deps/setup.py
@@ -22,7 +22,7 @@ from setuptools import setup
 DEPS = [
     'aenum',
     'jinja2',
-    'orderedset',
+    'ordered_set',
     'plyplus',
     'pyelftools',
     'sel4-deps',

--- a/tools/python-deps/setup.py
+++ b/tools/python-deps/setup.py
@@ -22,14 +22,13 @@ from setuptools import setup
 DEPS = [
     'aenum',
     'jinja2',
-    'ordered_set',
+    'ordered-set',
     'plyplus',
     'pyelftools',
     'sel4-deps',
     'pycparser',
     'pyfdt',
     'concurrencytest',
-
     # capDL deps
     'sortedcontainers',
     'hypothesis',
@@ -37,7 +36,7 @@ DEPS = [
 
 setup(
     name='camkes-deps',
-    version='0.7.2',
+    version='0.7.3',
     description='Metapackage for downloading build dependencies for CAmkES',
     url='https://docs.sel4.systems/CAmkES/',
     license='BSD2',

--- a/tools/python-deps/setup.py
+++ b/tools/python-deps/setup.py
@@ -10,11 +10,17 @@ Setup script for dependency metapackage.
 
 To add a python dependency, add it to the DEPS list below.
 
+To publish using these instructions, you need the virtualenv package 
+installed, and a properly set up ~/.pypirc file.
+
 To publish to pypitest:
-python setup.py sdist upload -r pypitest
+python3 -m build
+twine upload -r testpypi dist/*
 
 To publish to pypi:
-python setup.py sdist upload -r pypi
+python3 -m build
+twine upload -r pypi dist/*
+
 """
 
 from setuptools import setup
@@ -23,6 +29,7 @@ DEPS = [
     'aenum',
     'jinja2',
     'ordered-set',
+    'orderedset', # For older source trees: remove in 0.7.3
     'plyplus',
     'pyelftools',
     'sel4-deps',
@@ -36,11 +43,19 @@ DEPS = [
 
 setup(
     name='camkes-deps',
-    version='0.7.3',
+    version='0.7.2',
     description='Metapackage for downloading build dependencies for CAmkES',
+    long_description = """
+The CAmkES tool has many python dependencies.  This package depends on them all
+so that installing this package will pull in all the necessary packages.
+
+This package is maintained as part of https://github.com/seL4/camkes-tool.git, 
+in directory https://github.com/seL4/camkes-tool/tree/master/tools/python-deps
+""",
+    long_description_content_type = "text/markdown",
     url='https://docs.sel4.systems/CAmkES/',
     license='BSD2',
     author='TrustworthySystems',
-    author_email='Stephen.Sherratt@data61.csiro.au',
+    author_email='pypi@trustworthy.systems',
     install_requires=DEPS,
 )


### PR DESCRIPTION
The orderedset PyPi package no longer works with Python 3.10,
and has not been updated for years.

Replace it with the functionally equivalent (but maintained) ordered-set
package.

Signed-off-by: Peter Chubb <peter.chubb@unsw.edu.au>