### PR TITLE
component.common: Align morecore region to 0x1000

### DIFF
--- a/camkes/templates/component.common.c
+++ b/camkes/templates/component.common.c
@@ -256,7 +256,7 @@ int /*? b.name ?*/_post(void) {
 #ifdef CONFIG_CAMKES_DEFAULT_HEAP_SIZE
 /*- set heap_size = configuration[me.name].get('heap_size', 'CONFIG_CAMKES_DEFAULT_HEAP_SIZE') -*/
 
-static char heap [/*? heap_size ?*/];
+static char ALIGN(PAGE_SIZE_4K) heap [/*? heap_size ?*/];
 extern char *morecore_area;
 extern size_t morecore_size;
 #else


### PR DESCRIPTION
This region is used for mmap and brk allocations. The implementations
assume that it is 4k aligned. If the alignment isn't obeyed then memory
errors are possible.

Signed-off-by: Kent McLeod <kent@kry10.com>