### PR TITLE
serial: add config options for different ports

### DIFF
--- a/components/plat/pc99/plat/CMakeLists.txt
+++ b/components/plat/pc99/plat/CMakeLists.txt
@@ -8,3 +8,15 @@ cmake_minimum_required(VERSION 3.8.2)
 
 DeclareCAmkESComponent(PIT)
 DeclareCAmkESComponent(Serial)
+
+if(LibPlatSupportX86ConsoleDeviceEGA)
+    message("LibPlatSupportX86ConsoleDeviceEGA is on.")
+elseif(LibPlatSupportX86ConsoleDevice)
+    message("Serial port ${LibPlatSupportX86ConsoleDevice} selected.")
+    CAmkESAddImportPath(
+        ${CMAKE_CURRENT_LIST_DIR}/components/serial_${LibPlatSupportX86ConsoleDevice}/
+    )
+else()
+    message("Automatically select com1 for serial port.")
+    CAmkESAddImportPath(${CMAKE_CURRENT_LIST_DIR}/components/serial_com1)
+endif()

--- a/components/plat/pc99/plat/components/serial_com1/Serial.camkes
+++ b/components/plat/pc99/plat/components/serial_com1/Serial.camkes
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022, UNSW (ABN 57 195 873 179)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+component Serial {
+    hardware;
+    provides IOPort serial;
+    emits Irq4 serial_irq;
+    attribute string serial_attributes = "0x3f8:0x3ff";
+    attribute string serial_irq_irq_type = "isa";
+    attribute int serial_irq_irq_ioapic = 0;
+    attribute int serial_irq_irq_ioapic_pin = 4;
+    attribute int serial_irq_irq_vector = 4;
+}

--- a/components/plat/pc99/plat/components/serial_com2/Serial.camkes
+++ b/components/plat/pc99/plat/components/serial_com2/Serial.camkes
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022, UNSW (ABN 57 195 873 179)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+component Serial {
+    hardware;
+    provides IOPort serial;
+    emits Irq4 serial_irq;
+    attribute string serial_attributes = "0x2f8:0x2ff";
+    attribute string serial_irq_irq_type = "isa";
+    attribute int serial_irq_irq_ioapic = 0;
+    attribute int serial_irq_irq_ioapic_pin = 3;
+    attribute int serial_irq_irq_vector = 3;
+}

--- a/components/plat/pc99/plat/components/serial_com3/Serial.camkes
+++ b/components/plat/pc99/plat/components/serial_com3/Serial.camkes
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022, UNSW (ABN 57 195 873 179)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+component Serial {
+    hardware;
+    provides IOPort serial;
+    emits Irq4 serial_irq;
+    attribute string serial_attributes = "0x3e8:0x3ef";
+    attribute string serial_irq_irq_type = "isa";
+    attribute int serial_irq_irq_ioapic = 0;
+    attribute int serial_irq_irq_ioapic_pin = 4;
+    attribute int serial_irq_irq_vector = 4;
+}

--- a/components/plat/pc99/plat/components/serial_com4/Serial.camkes
+++ b/components/plat/pc99/plat/components/serial_com4/Serial.camkes
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022, UNSW (ABN 57 195 873 179)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+component Serial {
+    hardware;
+    provides IOPort serial;
+    emits Irq4 serial_irq;
+    attribute string serial_attributes = "0x2e8:0x2ef";
+    attribute string serial_irq_irq_type = "isa";
+    attribute int serial_irq_irq_ioapic = 0;
+    attribute int serial_irq_irq_ioapic_pin = 3;
+    attribute int serial_irq_irq_vector = 3;
+}

--- a/components/plat/pc99/plat/serial.camkes
+++ b/components/plat/pc99/plat/serial.camkes
@@ -4,13 +4,4 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-component Serial {
-    hardware;
-    provides IOPort serial;
-    emits Irq4 serial_irq;
-    attribute string serial_attributes = "0x3f8:0x3ff";
-    attribute string serial_irq_irq_type = "isa";
-    attribute int serial_irq_irq_ioapic = 0;
-    attribute int serial_irq_irq_ioapic_pin = 4;
-    attribute int serial_irq_irq_vector = 4;
-}
+import <Serial.camkes>;


### PR DESCRIPTION
The previous Serial component assumes that only serial port com1
is used. Since users are able to config serial ports, the Serial
component should also be able to include a different definition
based on the libplatsupport CMake configuration values.

Signed-off-by: Jingyao Zhou <jingyao.zhou@unsw.edu.au>