### PR TITLE
libsel4camkes: Expose get_virtqueue_channel

### DIFF
--- a/libsel4camkes/include/camkes/virtqueue.h
+++ b/libsel4camkes/include/camkes/virtqueue.h
@@ -55,6 +55,17 @@ extern camkes_virtqueue_channel_t camkes_virtqueue_channels[MAX_CAMKES_VIRTQUEUE
 extern int num_registered_virtqueue_channels;
 
 /**
+ * Get the virtqueue channel associated with the CAmkES virtqueue ID. Only return if
+ * a valid virtqueue is found.
+ *
+ * @param role                  Role of the virtqueue, either device or driver.
+ * @param camkes_virtqueue_id   Unique ID of the virtqueue as specified in CAmkES.
+ *
+ * @return Returns a valid virtqueue channel or NULL if invalid.
+*/
+camkes_virtqueue_channel_t *get_virtqueue_channel(virtqueue_role_t role, unsigned int camkes_virtqueue_id);
+
+/**
  * @brief      Convert a string name to a camkes virtqueue channel id.
  *
  * When a camkes virtqueue is registered, a numeric ID and a string name are provided

--- a/libsel4camkes/src/virtqueue.c
+++ b/libsel4camkes/src/virtqueue.c
@@ -55,7 +55,7 @@ void camkes_virtqueue_buffer_free(virtqueue_driver_t *virtqueue, void *buffer)
     allocator->head = idx;
 }
 
-static camkes_virtqueue_channel_t *get_virtqueue_channel(virtqueue_role_t role, unsigned int camkes_virtqueue_id)
+camkes_virtqueue_channel_t *get_virtqueue_channel(virtqueue_role_t role, unsigned int camkes_virtqueue_id)
 {
     /* Check that the virtqueue id is in a valid range */
     if (camkes_virtqueue_id > MAX_CAMKES_VIRTQUEUE_ID) {
@@ -110,7 +110,8 @@ int camkes_virtqueue_driver_init_with_recv(virtqueue_driver_t *driver, unsigned 
         *recv_badge = channel->recv_badge;
     }
 
-    return camkes_virtqueue_driver_init_common(driver, channel->channel_buffer, channel->queue_len, channel->channel_buffer_size,
+    return camkes_virtqueue_driver_init_common(driver, channel->channel_buffer, channel->queue_len,
+                                               channel->channel_buffer_size,
                                                channel->notify, BLOCK_SIZE) ? -1 : 0;
 }
 
@@ -134,7 +135,8 @@ int camkes_virtqueue_device_init_with_recv(virtqueue_device_t *device, unsigned 
         *recv_badge = channel->recv_badge;
     }
 
-    return camkes_virtqueue_device_init_common(device, channel->channel_buffer, channel->queue_len, channel->notify) ? -1 : 0;
+    return camkes_virtqueue_device_init_common(device, channel->channel_buffer, channel->queue_len,
+                                               channel->notify) ? -1 : 0;
 }
 
 void *camkes_virtqueue_device_offset_to_buffer(virtqueue_device_t *virtqueue, uintptr_t offset)


### PR DESCRIPTION
Exposing this function allows us to play with the underlying channels and their buffers.

Test with: https://github.com/seL4/seL4_projects_libs/pull/88