### PR TITLE
General Multicore Improvements

### DIFF
--- a/camkes/templates/component.common.c
+++ b/camkes/templates/component.common.c
@@ -42,6 +42,12 @@
 
 /*? macros.show_includes(me.type.includes) ?*/
 
+/*- if 'affinity' in configuration[me.name].keys() -*/
+#if(/*? configuration[me.name].get('affinity') ?*/ >= CONFIG_MAX_NUM_NODES)
+#error "Invalid Affinity Value of /*? configuration[me.name].get('affinity') ?*/"
+#endif
+/*- endif -*/
+
 static void (* _putchar)(int c);
 
 void set_putchar(void (*putchar)(int c)) {

--- a/camkes/templates/component.common.c
+++ b/camkes/templates/component.common.c
@@ -74,6 +74,10 @@ const char *get_instance_name(void) {
     return name;
 }
 
+int get_instance_affinity(void) {
+    return /*? configuration[me.name].get('affinity', options.default_affinity) ?*/;
+}
+
 /*- set cnode_size = configuration[me.address_space].get('cnode_size_bits') -*/
 /*- if cnode_size -*/
         /*- if isinstance(cnode_size, six.string_types) -*/

--- a/camkes/templates/component.common.c
+++ b/camkes/templates/component.common.c
@@ -488,7 +488,8 @@ static void CONSTRUCTOR(CAMKES_SYSCALL_CONSTRUCTOR_PRIORITY+1) init(void) {
     /*- elif options.debug_fault_handlers and loop.last -*/
         /*- do thread_names.__setitem__(tcb, "fault_handler") -*/
         /*- do _tcb.__setattr__('prio', 255) -*/
-        /*- do _tcb.__setattr__('affinity', options.default_affinity) -*/
+        /*- set thread_affinity = configuration[me.name].get("affinity", options.default_affinity) -*/
+        /*- do _tcb.__setattr__('affinity', thread_affinity) -*/
         /*- do _tcb.__setattr__('max_prio', options.default_max_priority) -*/
 
     /*- else -*/

--- a/camkes/templates/component.template.h
+++ b/camkes/templates/component.template.h
@@ -23,6 +23,7 @@
 /*- endfor -*/
 
 const char *get_instance_name(void);
+int get_instance_affinity(void);
 
 /* Attributes */
 


### PR DESCRIPTION
These commits make the following general improvements: 
- add a camkes function to allow a component to get the affinity that was set for it in the camkes config
- add a build time error checking for the affinity and num_vcpus attributes to avoid needing to wait for runtime errors to occur
- allow a components fault handler thread to always be on the same core as it's control thread when the affinity attribute is set