### PR TITLE
cmake: fix endmacro()

### DIFF
--- a/camkes/templates/camkes-gen.cmake
+++ b/camkes/templates/camkes-gen.cmake
@@ -42,7 +42,7 @@ macro(ParentListAppend list)
     set(local_list_value "${${list}}")
     list(APPEND local_list_value ${ARGN})
     set(${list} "${local_list_value}" PARENT_SCOPE)
-endmacro(ParentListAppend list)
+endmacro(ParentListAppend)
 
 # Helper function for declaring a generated file
 function(CAmkESGen output item template)


### PR DESCRIPTION
That `endmacro()` takes the name as parameter is legacy already, but the parameters are not supposed to be listed there. This is the minimal change. Actually I'd prefer to change it to `endmacro()` everywhere in the file, as this also removes some redundancy then.