### PR TITLE
camkes: improve error messages

### DIFF
--- a/camkes/templates/component.template.h
+++ b/camkes/templates/component.template.h
@@ -173,6 +173,9 @@ const char *get_instance_name(void);
             /*? raise(TemplateError('Missing DTB path for the %s seL4DTBHardware connection.' % config_name)) ?*/
         /*- endif -*/
         /*- set dtb = dtb_query[0] -*/
+        /*- if not 'reg' in dtb -*/
+            /*? raise(TemplateError('No reg attribute in DTB path for the %s seL4DTBHardware connection.' % (config_name))) ?*/
+        /*- endif -*/
         /*- set num_registers = len(dtb['reg']) // (dtb['this_address_cells'][0] + dtb['this_size_cells'][0]) -*/
         /*# Declare all the initialised buffers #*/
         /*- for i in range(0, num_registers) -*/


### PR DESCRIPTION
If there are mismatches in the device tree, it's helpful to know which node cause the problem, and what exactly the problem was. Without these messages, it was quite painful to figure out what exactly failed here.