### PR TITLE
python: sanitize number formatting

### DIFF
--- a/camkes/runner/Context.py
+++ b/camkes/runner/Context.py
@@ -65,7 +65,7 @@ def new_context(entity, assembly, render_state, state_key, outfile_name,
         if obj_space else None,
 
         # Cap allocator
-        'alloc_cap': None if cap_space is None else \
+        'alloc_cap': None if cap_space is None else
                 (lambda name, obj, **kwargs: alloc_cap((entity.label(),
                                                         cap_space), cap_space, name, obj, **kwargs)),
 
@@ -80,7 +80,7 @@ def new_context(entity, assembly, render_state, state_key, outfile_name,
                 # you see `set y = alloc('foo', bar, moo)` in template code, think:
                 #  set x = alloc_obj('foo_obj', bar)
                 #  set y = alloc_cap('foo_cap', x, moo)
-                'alloc': None if cap_space is None else \
+                'alloc': None if cap_space is None else
                 (lambda name, type, label=entity.label(), **kwargs:
                  alloc_cap((entity.label(), cap_space), cap_space, name,
                            alloc_obj((entity.label(), obj_space), obj_space, '%s_%s' %
@@ -94,14 +94,14 @@ def new_context(entity, assembly, render_state, state_key, outfile_name,
                 # same shared variable. The local name (lname) will later be used by us
                 # to locate the relevant ELF frame(s) to remap. Note that we assume
                 # address spaces and CSpaces are 1-to-1.
-                'register_shared_variable': None if cap_space is None else \
+                'register_shared_variable': None if cap_space is None else
                 (lambda global_name, symbol, size, frame_size=None, paddr=None,
                  perm='RWX', cached=True, label=entity.parent.label(), with_mapping_caps=None:
                  register_shared_variable(
                      addr_space, obj_space, global_name, symbol, size, cap_space,
                      frame_size, paddr, perm, cached, label, with_mapping_caps)),
 
-                'get_shared_variable_backing_frames': None if cap_space is None else \
+                'get_shared_variable_backing_frames': None if cap_space is None else
                 (lambda global_name, size, frame_size=None, label=entity.parent.label():
                  get_shared_variable_backing_frames(
                     obj_space, global_name, size, frame_size, label)),

--- a/camkes/runner/Context.py
+++ b/camkes/runner/Context.py
@@ -550,7 +550,7 @@ def get_shared_variable_backing_frames(obj_space, global_name, size, frame_size=
 
 def register_fill_frame(addr_space, symbol, fill, size, obj_space, label):
     '''
-    Take a symbol and create a collection of 4K frames that can comfortably store 
+    Take a symbol and create a collection of 4K frames that can comfortably store
     a region in the bootinfo.
 
     Return a static_assert checking that the symbol is of the correct size

--- a/camkes/runner/Context.py
+++ b/camkes/runner/Context.py
@@ -28,7 +28,6 @@ import inspect
 import itertools
 import functools
 import numbers
-from math import log10
 import \
     ordered_set, os, pdb, re, six, sys, textwrap, math
 from capdl.Object import ObjectType, ObjectRights, ARMIRQMode
@@ -486,12 +485,11 @@ def register_shared_variable(addr_space, obj_space, global_name, symbol, size, c
     size = int(size)
     frame_size = calc_frame_size(size, frame_size, obj_space.spec.arch)
     num_frames = size//frame_size
-    digits = str(int(log10(num_frames + 1)) + 1)
-    namefmt = '%s_%0' + digits + 'd_obj'
+    digits = len(str(num_frames - 1))  # 0 frames is a no-op below anyway
     # If these frames have been allocated already then the allocator will return them.
     # Therefore calls to register_shared_variable with the same global_name have to have the same size.
     frames = [obj_space.alloc(ObjectType.seL4_FrameObject,
-                              name=namefmt % (global_name, i),
+                              name=f'{global_name}_{i:0{digits}}_obj',
                               size=frame_size,
                               label=label)
               for i in range(num_frames)]
@@ -539,10 +537,9 @@ def get_shared_variable_backing_frames(obj_space, global_name, size, frame_size=
     size = int(size)
     frame_size = calc_frame_size(size, frame_size, obj_space.spec.arch)
     num_frames = size//frame_size
-    digits = str(int(log10(num_frames + 1)) + 1)
-    namefmt = '%s_%0' + digits + 'd_obj'
+    digits = len(str(num_frames - 1))  # 0 frames is a no-op below anyway
     return [obj_space.alloc(ObjectType.seL4_FrameObject,
-                            name=namefmt % (global_name, i),
+                            name=f'{global_name}_{i:0{digits}}_obj',
                             size=frame_size,
                             label=label)
             for i in range(num_frames)]
@@ -557,15 +554,14 @@ def register_fill_frame(addr_space, symbol, fill, size, obj_space, label):
     '''
     assert addr_space
     number_frames = size//4096
-    digits = str(int(log10(number_frames + 1)) + 1)
-    namefmt = '%s_%s_%0' + digits + 'd_obj'
+    digits = len(str(number_frames - 1))  # 0 frames is a no-op below anyway
     frames = []
     for i in range(number_frames):
         fill_str = ['%d %d %s %d' % (0, 4096 if (size - (i * 4096)) >=
                                      4096 else (size - (i * 4096)), fill, i * 4096)]
-        name = namefmt % (symbol, label, i)
         frames.append(obj_space.alloc(ObjectType.seL4_FrameObject,
-                                      name=name, label=label, fill=fill_str, size=4096))
+                                      name=f'{symbol}_{label}_{i:0{digits}}_obj',
+                                      label=label, fill=fill_str, size=4096))
     caps = [Cap(frame, read=True, write=False, grant=False) for frame in frames]
     sizes = [4096] * number_frames
     addr_space.add_symbol_with_caps(symbol, sizes, caps)
@@ -582,9 +578,10 @@ def register_stack_symbol(addr_space, symbol, size, obj_space, label):
     '''
     assert addr_space
     number_frames = size//4096
-    digits = str(int(log10(number_frames + 1)) + 1)
-    namefmt = 'stack_%s_%0' + digits + 'd_%s_obj'
-    frames = [obj_space.alloc(ObjectType.seL4_FrameObject, name=namefmt % (symbol, i, label), label=label, size=4096)
+    digits = len(str(number_frames - 1))  # 0 frames is a no-op below anyway
+    frames = [obj_space.alloc(ObjectType.seL4_FrameObject,
+                              name=f'stack_{symbol}_{i:0{digits}}_{label}_obj',
+                              label=label, size=4096)
               for i in range(number_frames)]
     # We create 2 additional mappings with None caps that are for the guard pages.
     sizes = [4096] * (number_frames + 2)


### PR DESCRIPTION
- Fix the calculation of leading zeros. Using "`int(log10(cnt + 1)) + 1`" is broken, it evaluates to 2 for cnt=9, and thus results in the strings "`00`"-"`08`". Using "`1 if (n <= 1) else (1 + int(log10(n - 1)))`" seems overly complicated here, so a naive and readable way is used.
- switch to f-strings for better readability
