### PR TITLE
parser,fdtQueryEngine: Fix parser bug with queries

### DIFF
--- a/camkes/parser/fdtQueryEngine.py
+++ b/camkes/parser/fdtQueryEngine.py
@@ -10,6 +10,7 @@ import argparse
 
 import functools
 import os
+import copy
 import six
 import re
 import logging
@@ -405,7 +406,12 @@ class FdtQueryEngine:
 
     def query(self, attr):
         assert isinstance(attr, list)
-        return [self._match_attr_dict(attr_dict) for attr_dict in attr]
+
+        # Make a copy of each internal dict as _match_attr_dict mutates
+        # its arguments but we aren't allowed to mutate our arguments.
+        # Use deepcopy because the dict could contain more compound objects
+        # but can't contain recursive references.
+        return [self._match_attr_dict(copy.deepcopy(attr_dict)) for attr_dict in attr]
 
 
 class DtbMatchQuery(Query):


### PR DESCRIPTION
When using dtb queries on a type that has multiple instances, when the second or additional instances are evaluated, their settings have bad values: `gpio_mux_server1.gpio.dtb = dtb({})` instead of the expected: `gpio_mux_server1.gpio.dtb = dtb({"path" : "/gpio@2200000"})`.  This is due to a parser bug that mutates the internal dictionary object instead of mutating a copy.

Switching to a deep copy avoids mutating the AST object.

```
component GPIOMUXServer {

    emits FDT dummy_source;
    consumes FDT gpio;
    consumes FDT mux;

    composition {

        connection seL4DTBHardware gpio_conn(from dummy_source, to gpio);
        connection seL4DTBHardware mux_conn(from dummy_source, to mux);

    }

    configuration {
        gpio.dtb = dtb({"path" : "/gpio@2200000"});
        mux.dtb = dtb({"path" : "/pinmux@2430000"});

    }
}

assembly {
  composition {
        component GPIOMUXServer gpio_mux_server0;
        component GPIOMUXServer gpio_mux_server1;
  }
  configuration {}

}

```