### PR TITLE
Fix camkes-deps build

### DIFF
--- a/tools/python-deps/setup.py
+++ b/tools/python-deps/setup.py
@@ -29,7 +29,7 @@ DEPS = [
     'aenum',
     'jinja2>=3.0.0',
     'ordered-set',
-    'orderedset',  # For older source trees: remove in 0.7.4
+    "orderedset;python_version<='3.10'", # For older source trees: remove in 0.7.4
     'plyplus',
     'pyelftools',
     'sel4-deps',


### PR DESCRIPTION
orderedset fails to build for python >= 3.11 as discussed here: https://github.com/seL4/camkes-tool/issues/124.

Conditionally including it as a dependency for versions <= 3.10, bypasses the issue temporarily.