### PR TITLE
camkes-deps: fully remove orderedset; bump version

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: seL4/ci-actions/link-check@master
         with:
           exclude: js/node_modules
+          # produces 403 for link checker:
+          exclude_urls: "http://jinja.pocoo.org/docs/"
 
   style:
     name: Style

--- a/tools/check_deps.py
+++ b/tools/check_deps.py
@@ -157,7 +157,7 @@ DEPENDENCIES = {
                       PythonModule('plyplus', 'Python parsing module'),
                       PythonModule('ply', 'Python parsing module'),
                       PythonModule('elftools', 'Python ELF parsing module'),
-                      PythonModule('ordered_set', 'Python OrderedSet module (orderedset)'),
+                      PythonModule('ordered_set', 'Python OrderedSet module (ordered-set)'),
                       PythonModuleWith('six', 'Python 2/3 compatibility layer', 'assertCountEqual'),
                       PythonModule('sqlite3', 'Python SQLite module'),
                       PythonModule('pyfdt', 'Python flattened device tree parser')),

--- a/tools/python-deps/setup.py
+++ b/tools/python-deps/setup.py
@@ -10,7 +10,7 @@ Setup script for dependency metapackage.
 
 To add a python dependency, add it to the DEPS list below.
 
-To publish using these instructions, you need the virtualenv package 
+To publish using these instructions, you need the virtualenv package
 installed, and a properly set up ~/.pypirc file.
 
 To publish to pypitest:
@@ -29,7 +29,6 @@ DEPS = [
     'aenum',
     'jinja2>=3.0.0',
     'ordered-set',
-    'orderedset',  # For older source trees: remove in 0.7.4
     'plyplus',
     'pyelftools',
     'sel4-deps',
@@ -43,7 +42,7 @@ DEPS = [
 
 setup(
     name='camkes-deps',
-    version='0.7.3',
+    version='0.7.4',
     description='Metapackage for downloading build dependencies for CAmkES',
     long_description="""
 The CAmkES tool has many python dependencies.  This package depends on them all
@@ -58,4 +57,5 @@ in directory https://github.com/seL4/camkes-tool/tree/master/tools/python-deps
     author='TrustworthySystems',
     author_email='pypi@trustworthy.systems',
     install_requires=DEPS,
+    python_requires='>=3'
 )


### PR DESCRIPTION
- commit 4f7bca1931 replaced orderedset by the maintained ordered-set, but did no yet remove the dependency. Since on more recent python version the dependency install now fails, we are removing it completely.

- make python 3 requirement explicit

To be released on PyPi simultaneously with the upcoming CAmkES release.

Closes #124