### PR TITLE
recreate camkes-3.11.0 release state

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-camkes-3.11.0-dev
+camkes-3.11.0


### PR DESCRIPTION
This reverts commit 0f02fe2d18393df04eb7017b6603aca7b474bb3a to get CI to trigger on the release commit state.