### PR TITLE
github: use central CI workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+# Copyright 2025, Proofcraft Pty Ltd
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
@@ -6,23 +6,9 @@
 
 name: PR
 
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 
 jobs:
-  gitlint:
-    name: Gitlint
-    runs-on: ubuntu-latest
-    steps:
-    - uses: seL4/ci-actions/gitlint@master
-
-  whitespace:
-    name: 'Trailing Whitespace'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: seL4/ci-actions/git-diff-check@master
-
-  shell:
-    name: 'Portable Shell'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: seL4/ci-actions/bashisms@master
+  pr-checks:
+    name: Checks
+    uses: seL4/ci-actions/.github/workflows/pr.yml@master

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,28 +10,9 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
-  check:
-    name: License Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: seL4/ci-actions/license-check@master
-
-  links:
-    name: Links
-    runs-on: ubuntu-latest
-    steps:
-      - uses: seL4/ci-actions/link-check@master
-        with:
-          exclude: js/node_modules
-          # produces 403 for link checker:
-          exclude_urls: "http://jinja.pocoo.org/docs/"
-
-  style:
-    name: Style
-    runs-on: ubuntu-latest
-    steps:
-    - uses: seL4/ci-actions/style@master
-      with:
-        diff_only: true
+  checks:
+    name: Checks
+    uses: seL4/ci-actions/.github/workflows/push.yml@master

--- a/.linkcheck-ignore.yml
+++ b/.linkcheck-ignore.yml
@@ -1,0 +1,6 @@
+# Copyright 2025, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+urls:
+  - http://jinja.pocoo.org/docs/


### PR DESCRIPTION
Use GitHub workflow_call feature to reduce workflow duplication.

The `linkcheck-ignore.yml` feature doesn't really exist yet, but I'm planning to add it this weekend.