### PR TITLE
docs: provide two more anchors for tutorials

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,7 @@ of these terms are made explicit below.
   assembly block.
 
 **Connection**
+{: #connection}
 
 > An instantiation of a connector. Connections connect two _instances_. Because
   the instantiation of a connector does not really specialise the connector in
@@ -193,6 +194,7 @@ of these terms are made explicit below.
 > The interface type that represents shared memory semantics.
 
 **Procedure**
+{: #procedure}
 
 > An interface with function call semantics. Procedures consist of a series of
   methods that can be invoked independently.


### PR DESCRIPTION
Fixed markdown in https://github.com/seL4/sel4-tutorials/pull/115 means these are now targeted.