### PR TITLE
updates for gcc-14

### DIFF
--- a/camkes/templates/component.template.h
+++ b/camkes/templates/component.template.h
@@ -110,6 +110,10 @@ seL4_Word /*? u.name ?*/_get_sender_id(void);
 /*- endfor -*/
 
 /*- for c in me.type.consumes -*/
+    /*- if c.type == "Notification" -*/
+    seL4_CPtr /*? c.name ?*/_notification(void);
+    /*- endif -*/
+
     /*# HACK: Connection-specific check here to just be nice to the user and
      *# trigger a compile-time warning if they try to use functions that aren't
      *# implemented.


### PR DESCRIPTION
As in seL4/camkes#34, this PR collects updates to make the CAmkES tests pass with gcc-14.

The errors here are all because -Werror=implicit-function-declaration is now default, which means some previously undeclared functions that were used in the tests now need prototypes. These are:

- `*_get_sender_id` for RPC connectors (declared in the component.h file, which is not entirely ideal, because it doesn't see the connector type, just the interface, but if the function is declared for the wrong connector type, not using it does not cause an error)
- `_notification` functions for Notification interfaces.

Should be merged after #161