### PR TITLE
Pickle dump is not flushed before exit

### DIFF
--- a/camkes/runner/__main__.py
+++ b/camkes/runner/__main__.py
@@ -308,6 +308,7 @@ def main(argv, out, err):
     if options.save_object_state is not None:
         # Write the render_state to the supplied outfile
         pickle.dump(render_state, options.save_object_state)
+        options.save_object_state.close()
 
     sys.exit(0)
 


### PR DESCRIPTION
Hi, I have been playing around with seL4 recently and had faced the following error

```
Traceback (most recent call last):
  File "camkes-project/projects/capdl/python-capdl-tool/../cdl_utils/capdl_linker.py", line 153, in <module>
    sys.exit(main())
             ~~~~^^
  File "camkes-project/projects/capdl/python-capdl-tool/../cdl_utils/capdl_linker.py", line 127, in main
    allocator_state = pickle.load(args.manifest_in)
EOFError: Ran out of input
```

The pickle file generated seems to be empty, possibly because it is not flushed before `sys.exit` is called.

`.close()` implicitly flushes the file and also closes it.