### PR TITLE
workflows: use ${{ variable }} not invalid $${{

### DIFF
--- a/.github/workflows/camkes-deploy.yml
+++ b/.github/workflows/camkes-deploy.yml
@@ -103,7 +103,7 @@ jobs:
         uses: seL4/ci-actions/camkes-hw@master
         with:
           platform: ${{ matrix.platform }}
-          index: $${{ strategy.job-index }}
+          index: ${{ strategy.job-index }}
         env:
           HW_SSH: ${{ secrets.HW_SSH }}
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+<!--
+     Copyright 2018, Data61, CSIRO (ABN 41 687 119 230)
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Version history for CAmkES
 
 <!-- This file should be word wrapped to 120 characters -->


### PR DESCRIPTION
I'm not entirely sure how this worked... but I guess GitHub ignores the extra $ sign.