### PR TITLE
Support units in domain schedule declarations

### DIFF
--- a/camkes/ast/objects.py
+++ b/camkes/ast/objects.py
@@ -22,6 +22,7 @@ from .exception import ASTError
 from .location import SourceLocation
 from camkes.internal.frozendict import frozendict
 from camkes.internal.isinstancefallback import isinstance_fallback
+from capdl import DomainDurationUnit
 import abc
 import collections
 import itertools
@@ -145,8 +146,9 @@ class Reference(ASTObject):
 
 
 @ast_property("items", lambda i: isinstance(i, (list, tuple)) and
-              all(isinstance(item, (tuple, list)) and len(item) == 2 and
-                  all(isinstance(n, numbers.Number) for n in item) for item in i))
+              all(isinstance(item, (tuple, list)) and len(item) in [2, 3] and
+                  all(isinstance(n, numbers.Number) for n in item[:2]) and
+                  all(isinstance(n, DomainDurationUnit) for n in item[2:]) for item in i))
 class Schedule(ASTObject):
 
     def __init__(self, items=None, location=None):

--- a/camkes/parser/camkes.g
+++ b/camkes/parser/camkes.g
@@ -64,6 +64,7 @@ ID: '[a-zA-Z_]\w*'
             SIGNED: 'signed';
             STRUCT: 'struct';
             STRING: 'string';
+            TICKS: 'ticks';
             THREAD: 'thread';
             THREADS: 'threads';
             TRUE1: 'True';
@@ -71,6 +72,7 @@ ID: '[a-zA-Z_]\w*'
             TO: 'to';
             UINT64_T: 'uint64_t';
             UNSIGNED: 'unsigned';
+            US: 'us';
             USES: 'uses';
             VOID: 'void';
             WITH: 'with';
@@ -88,7 +90,8 @@ configuration_sing: CONFIGURATION reference ';'
                   | configuration_decl;
 
 schedule_defn: SCHEDULE '\{' '\[' schedule_item (',' schedule_item)+ ','? '\]' '\}';
-schedule_item: '\(' number ',' number '\)';
+schedule_unit: TICKS | US;
+schedule_item: '\(' number ',' number schedule_unit? '\)';
 
 attribute_decl: attribute_parameter ('=' item)? ;
 

--- a/camkes/parser/stage3.py
+++ b/camkes/parser/stage3.py
@@ -25,6 +25,7 @@ from camkes.ast import Assembly, Attribute, AttributeReference, Component, \
     LiftedAST, Method, Mutex, normalise_type, Parameter, Procedure, Provides, \
     Reference, Schedule, Semaphore, BinarySemaphore, QueryObject, Setting, \
     SourceLocation, Uses, Struct
+from capdl import DomainDurationUnit
 from .base import Parser
 from .exception import ParseError
 import numbers
@@ -326,9 +327,24 @@ def _lift_schedule_decl(location, *args):
     return schedule_defn
 
 
+def _lift_schedule_unit(location, *args):
+    assert len(args) == 1
+
+    if args[0] == 'ticks':
+        return DomainDurationUnit.Ticks
+    elif args[0] == 'us':
+        return DomainDurationUnit.Us
+    else:
+        raise ParseError('illegal domains unit value \'%s\'' % args[0], location)
+
+
 def _lift_schedule_item(location, *args):
-    assert len(args) == 2
-    return (args[0], args[1])
+    assert len(args) in [2, 3]
+
+    if len(args) == 3:
+        return (args[0], args[1], args[2])
+    else:
+        return (args[0], args[1])
 
 
 def _lift_connection_defn(location, connector_ref, id, *ends):
@@ -797,6 +813,7 @@ LIFT = {
     'configuration_sing': _lift_configuration_sing,
     'schedule_defn': _lift_schedule_decl,
     'schedule_item': _lift_schedule_item,
+    'schedule_unit': _lift_schedule_unit,
     'connection_defn': _lift_connection_defn,
     'connection_end': _lift_connection_end,
     'connector_decl': _lift_connector_decl,


### PR DESCRIPTION
Mostly useful for MCS, where ticks are often platform-specific in the domain schedule. However, it is also permitted for non-MCS as well.

Test with: https://github.com/seL4/capdl/pull/95