### PR TITLE
Release camkes 3.13.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,16 @@
 
 ### Changes
 
+
+### Upgrade Notes
+---
+
+## camkes-3.13.0 2026-07-22
+
+Using seL4 version 16.0.0
+
+### Changes
+
 * Add support for GCC 14 and python >= 3.10
 * Add support for concurrent unit tests
 * Add support for units in the domain schedule (ticks or microseconds)

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-camkes-3.13.0
+camkes-3.13.0-dev

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-camkes-3.12.0-dev
+camkes-3.13.0


### PR DESCRIPTION
Release commits for the camkes-3.13.0 release (VERSION + change log bump + post-release version bump).

Should be merged after CI for https://github.com/seL4/capdl/pull/101 has settled.